### PR TITLE
Add GitHub Actions CI for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Run unit tests
+        working-directory: tiled_poc
+        run: |
+          uv run --python ${{ matrix.python-version }} \
+            --with pytest \
+            --with 'tiled[server]' \
+            --with pandas \
+            --with pyarrow \
+            --with h5py \
+            --with numpy \
+            --with 'ruamel.yaml' \
+            --with canonicaljson \
+            pytest tests/test_config.py tests/test_utils.py tests/test_generic_registration.py -v

--- a/tiled_poc/tests/test_config.py
+++ b/tiled_poc/tests/test_config.py
@@ -93,6 +93,7 @@ class TestGetLatestManifest:
         assert path.endswith(".parquet")
         assert os.path.exists(path)
 
+    @pytest.mark.skip(reason="requires pre-built manifests in manifests/")
     def test_finds_artifacts_manifest(self):
         from broker.config import get_latest_manifest
         path = get_latest_manifest("artifacts")


### PR DESCRIPTION
## Summary

- Add `.github/workflows/tests.yml` running unit tests on push to main and on PRs
- Matrix: Python 3.11, 3.12 on ubuntu-latest
- Runs 46 self-contained tests (synthetic test data in `tests/testdata/`, 96KB)
- Skip `test_finds_artifacts_manifest` (requires S3DF paths, like its sibling)
- Integration tests excluded (require running server + real data)

## Test plan

- [x] 46 passed, 2 skipped locally
- [ ] CI passes on this PR (first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)