### PR TITLE
refactor: remove legacy get_base_dir and single-dataset assumptions

### DIFF
--- a/tiled_poc/broker/bulk_register.py
+++ b/tiled_poc/broker/bulk_register.py
@@ -1,17 +1,3 @@
-#!/usr/bin/env -S uv run --script
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "tiled[server]",
-#     "pandas",
-#     "pyarrow",
-#     "h5py",
-#     "numpy",
-#     "ruamel.yaml",
-#     "canonicaljson",
-#     "sqlalchemy",
-# ]
-# ///
 """
 Generic Bulk Registration with SQLAlchemy.
 
@@ -35,30 +21,12 @@ When to use:
 When NOT to use:
 - Incremental updates (use register_catalog.py instead)
 - Server is running and serving queries
-
-Usage:
-    # Register with defaults (10 entities to catalog.db)
-    python bulk_register.py
-
-    # Register specific number of entities
-    python bulk_register.py -n 1000
-
-    # Register all entities to a specific database
-    python bulk_register.py -n 10000 -o catalog-bulk.db
-
-    # Force overwrite without prompting
-    python bulk_register.py -n 100 --force
-
-    # Environment variables still work as fallbacks
-    MAX_ENTITIES=10000 CATALOG_DB=catalog-bulk.db python bulk_register.py
 """
 
 import os
-import sys
 import time
 import json
 import hashlib
-import argparse
 from pathlib import Path
 
 import pandas as pd
@@ -67,8 +35,6 @@ from sqlalchemy import create_engine, text
 
 # Import from shared helpers
 from .config import (
-    get_base_dir,
-    get_latest_manifest,
     get_max_entities,
     get_catalog_db_path,
 )
@@ -101,11 +67,15 @@ END
 """
 
 
-def init_database(db_path):
+def init_database(db_path, readable_storage):
     """Initialize database with Tiled schema.
 
     Uses Tiled's catalog adapter to create schema, then returns
     a raw SQLAlchemy engine for bulk operations.
+
+    Args:
+        db_path: Path to the SQLite database file.
+        readable_storage: List of directories Tiled is allowed to read from.
     """
     from tiled.catalog import from_uri as catalog_from_uri
 
@@ -122,7 +92,7 @@ def init_database(db_path):
     catalog_from_uri(
         uri,
         writable_storage=str(Path(db_path).parent / "storage"),
-        readable_storage=[get_base_dir()],
+        readable_storage=readable_storage,
         init_if_not_exists=True,
     )
 
@@ -131,26 +101,7 @@ def init_database(db_path):
     return engine
 
 
-def load_manifests():
-    """Load entity and artifact manifests."""
-    base_dir = get_base_dir()
-    print(f"Loading manifests from {base_dir}...")
-
-    ent_path = get_latest_manifest("entities")
-    art_path = get_latest_manifest("artifacts")
-
-    print(f"  Entities:  {Path(ent_path).name}")
-    print(f"  Artifacts: {Path(art_path).name}")
-
-    ent_df = pd.read_parquet(ent_path)
-    art_df = pd.read_parquet(art_path)
-
-    print(f"  Rows: {len(ent_df)} entities, {len(art_df)} artifacts")
-
-    return ent_df, art_df
-
-
-def prepare_node_data(ent_df, art_df, max_entities, base_dir=None):
+def prepare_node_data(ent_df, art_df, max_entities, base_dir):
     """Prepare all node data for bulk insert.
 
     Reads all metadata columns dynamically from manifests -- no hardcoded
@@ -161,16 +112,12 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir=None):
         art_df: Artifact manifest DataFrame.
         max_entities: Maximum number of entities to process.
         base_dir: Base directory for resolving relative file paths.
-            Defaults to get_base_dir().
 
     Returns:
         ent_nodes: List of entity node dicts
         art_nodes: List of artifact node dicts (with placeholder parent)
         art_data_sources: List of data source info for artifacts
     """
-    if base_dir is None:
-        base_dir = get_base_dir()
-
     if "key" not in ent_df.columns:
         raise ValueError(
             "Entity manifest missing required 'key' column. "
@@ -593,111 +540,3 @@ def verify_registration(db_path):
    print(f'Data shape: {h[list(h.keys())[0]].read().shape}')
    "
 """)
-
-
-def parse_args():
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Bulk register entities to Tiled catalog using SQLAlchemy.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s                        # Register 10 entities (default)
-  %(prog)s -n 1000                # Register 1000 entities
-  %(prog)s -n 10000 -o bulk.db    # Register all to bulk.db
-  %(prog)s -n 100 --force         # Overwrite without prompting
-
-Environment variables (used as fallbacks):
-  MAX_ENTITIES           Number of entities (default: from config)
-  CATALOG_DB             Database filename (default: catalog.db)
-"""
-    )
-
-    parser.add_argument(
-        "-n", "--max-entities",
-        type=int,
-        default=None,
-        metavar="NUM",
-        help="Number of entities to register (default: 10 or MAX_ENTITIES)"
-    )
-
-    parser.add_argument(
-        "-o", "--output",
-        type=str,
-        default=None,
-        metavar="DB_NAME",
-        help="Output database filename (default: catalog.db or CATALOG_DB)"
-    )
-
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Overwrite existing database without prompting"
-    )
-
-    return parser.parse_args()
-
-
-def main():
-    args = parse_args()
-
-    print("=" * 60)
-    print("Generic Bulk Registration (SQLAlchemy + Trigger Rebuild)")
-    print("=" * 60)
-
-    # Determine database path (CLI > env var > config default)
-    from .config import get_service_dir
-
-    if args.output:
-        db_path = os.path.join(get_service_dir(), args.output)
-    elif os.environ.get("CATALOG_DB"):
-        db_path = os.path.join(get_service_dir(), os.environ.get("CATALOG_DB"))
-    else:
-        db_path = get_catalog_db_path()
-
-    # Determine max entities (CLI > env var > config default)
-    if args.max_entities is not None:
-        max_entities = args.max_entities
-    else:
-        max_entities = get_max_entities()
-
-    print(f"Database:       {db_path}")
-    print(f"Data dir:       {get_base_dir()}")
-    print(f"Max entities:   {max_entities}")
-    print()
-
-    # Check if database exists and handle --force
-    if os.path.exists(db_path) and not args.force:
-        print(f"WARNING: Database already exists: {db_path}")
-        response = input("Overwrite? [y/N]: ").strip().lower()
-        if response != 'y':
-            print("Aborted.")
-            sys.exit(0)
-
-    # Initialize database
-    print("Initializing database...")
-    engine = init_database(db_path)
-
-    # Load manifests
-    ent_df, art_df = load_manifests()
-
-    # Prepare data
-    ent_nodes, art_nodes, art_data_sources = prepare_node_data(
-        ent_df, art_df, max_entities
-    )
-
-    # Bulk register
-    print("\nStarting bulk registration...")
-    elapsed = bulk_register(engine, ent_nodes, art_nodes, art_data_sources)
-
-    # Calculate rate
-    total_nodes = len(ent_nodes) + len(art_nodes) + 1  # +1 for root
-    rate = total_nodes / elapsed if elapsed > 0 else 0
-    print(f"Rate: {rate:.0f} nodes/sec")
-
-    # Verify
-    verify_registration(db_path)
-
-
-if __name__ == "__main__":
-    main()

--- a/tiled_poc/broker/bulk_register.py
+++ b/tiled_poc/broker/bulk_register.py
@@ -33,11 +33,6 @@ import pandas as pd
 import canonicaljson
 from sqlalchemy import create_engine, text
 
-# Import from shared helpers
-from .config import (
-    get_max_entities,
-    get_catalog_db_path,
-)
 from .utils import (
     make_artifact_key,
     to_json_safe,

--- a/tiled_poc/broker/config.py
+++ b/tiled_poc/broker/config.py
@@ -6,7 +6,6 @@ Uses ruamel.yaml to preserve comments for round-trip editing.
 """
 
 import os
-import glob
 from pathlib import Path
 from ruamel.yaml import YAML
 
@@ -65,12 +64,6 @@ def get_config():
     return _config
 
 
-def get_base_dir():
-    """Get the base directory for schema data."""
-    cfg = get_config()
-    return f"{cfg['data_dir']}/data/{cfg['schema_version']}"
-
-
 def get_service_dir():
     """Get the service directory (where catalog.db and storage/ live)."""
     return get_config()["service_dir"]
@@ -79,40 +72,6 @@ def get_service_dir():
 def get_catalog_db_path():
     """Get full path to catalog.db."""
     return os.path.join(get_service_dir(), "catalog.db")
-
-
-def get_latest_manifest(prefix):
-    """Find latest manifest file by prefix.
-
-    Reads glob patterns from config.yml ``manifests`` section if available,
-    otherwise falls back to the default pattern ``manifest_{prefix}_*.parquet``.
-
-    Args:
-        prefix: "entities" or "artifacts"
-
-    Returns:
-        str: Path to the latest manifest file.
-
-    Raises:
-        FileNotFoundError: If no manifest file found.
-    """
-    cfg = get_config()
-    manifests_cfg = cfg.get("manifests", {})
-
-    if prefix in manifests_cfg:
-        pattern = manifests_cfg[prefix]
-        # Resolve relative patterns against base_dir
-        if not os.path.isabs(pattern):
-            pattern = os.path.join(get_base_dir(), pattern)
-    else:
-        # Fallback to default pattern
-        base_dir = get_base_dir()
-        pattern = f"{base_dir}/manifest_{prefix}_*.parquet"
-
-    files = sorted(glob.glob(pattern))
-    if not files:
-        raise FileNotFoundError(f"No manifest found matching: {pattern}")
-    return files[-1]  # Latest by timestamp in filename
 
 
 def get_tiled_url():

--- a/tiled_poc/broker/query_manifest.py
+++ b/tiled_poc/broker/query_manifest.py
@@ -18,7 +18,9 @@ Usage:
     manifest = query_catalog(filtered, artifact_type="mh_powder_30T")
 
     # Step 2: Load — returns raw arrays (no normalization)
-    arrays = load_artifacts(manifest, artifact_type="mh_powder_30T")
+    #   base_dir comes from the dataset's YAML config (e.g. config["base_dir"])
+    arrays = load_artifacts(manifest, artifact_type="mh_powder_30T",
+                            base_dir="/path/to/data")
     X = np.stack(arrays, dtype=np.float32)
 
     # Assemble Theta from the manifest (caller's choice of columns)
@@ -30,8 +32,6 @@ import os
 import h5py
 import numpy as np
 import pandas as pd
-
-from .config import get_base_dir
 
 
 def query_catalog(client, artifact_type, limit=None):
@@ -68,14 +68,14 @@ def query_catalog(client, artifact_type, limit=None):
     return pd.DataFrame(rows)
 
 
-def load_artifacts(manifest_df, artifact_type, base_dir=None):
+def load_artifacts(manifest_df, artifact_type, base_dir):
     """Load artifact arrays directly from HDF5 using locator columns.
 
     Args:
         manifest_df: DataFrame from query_catalog() containing locator columns.
         artifact_type: Artifact type string matching the query_catalog call.
-        base_dir: Base directory for resolving HDF5 file paths.
-            Defaults to value from config.
+        base_dir: Base directory for resolving relative HDF5 file paths.
+            Typically from the dataset's YAML config (config["base_dir"]).
 
     Returns:
         list[np.ndarray]: Raw arrays, one per manifest row, in row order.
@@ -86,9 +86,6 @@ def load_artifacts(manifest_df, artifact_type, base_dir=None):
         FileNotFoundError: If an HDF5 file referenced in the manifest does
             not exist.
     """
-    if base_dir is None:
-        base_dir = get_base_dir()
-
     path_col = f"path_{artifact_type}"
     dataset_col = f"dataset_{artifact_type}"
     index_col = f"index_{artifact_type}"

--- a/tiled_poc/config.yml
+++ b/tiled_poc/config.yml
@@ -18,9 +18,5 @@ broker:
   # Service directory (where catalog.db and storage/ live)
   service_dir: "/sdf/data/lcls/ds/prj/prjmaiqmag01/results/cwang31/proj-vdp/tiled_poc"
 
-  # Data directory root
-  data_dir: "/sdf/data/lcls/ds/prj/prjmaiqmag01/results/vdp"
-  schema_version: "schema_v1"
-
   # Registration defaults (override with MAX_ENTITIES env var)
   max_entities: 10

--- a/tiled_poc/examples/demo_dual_mode.py
+++ b/tiled_poc/examples/demo_dual_mode.py
@@ -32,11 +32,24 @@ import time
 from pathlib import Path
 
 import numpy as np
+from ruamel.yaml import YAML
 
 # Add tiled_poc directory to path for broker package imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from broker.config import get_tiled_url, get_api_key, get_base_dir, get_service_dir
+from broker.config import get_tiled_url, get_api_key, get_service_dir
+
+
+def _load_base_dirs():
+    """Load base_dir from each dataset YAML config in datasets/."""
+    yaml = YAML()
+    base_dirs = {}
+    datasets_dir = Path(__file__).parent.parent / "datasets"
+    for cfg_path in sorted(datasets_dir.glob("*.yaml")):
+        with open(cfg_path) as f:
+            cfg = yaml.load(f)
+        base_dirs[cfg["key"]] = cfg["base_dir"]
+    return base_dirs
 
 
 def _find_dataset_container(client, artifact_type):
@@ -45,8 +58,8 @@ def _find_dataset_container(client, artifact_type):
         container = client[key]
         ents = list(container.keys())[:1]
         if ents and f"path_{artifact_type}" in dict(container[ents[0]].metadata):
-            return container
-    return None
+            return key, container
+    return None, None
 
 
 def demo_mode_a_expert(client):
@@ -68,9 +81,16 @@ def demo_mode_a_expert(client):
 
     # Navigate to dataset-level container (root -> dataset containers -> entities)
     artifact_type = "mh_powder_30T"
-    dataset_client = _find_dataset_container(client, artifact_type)
+    dataset_key, dataset_client = _find_dataset_container(client, artifact_type)
     if dataset_client is None:
         print(f"  No dataset found with artifact_type={artifact_type}")
+        return
+
+    # Load base_dir for this dataset from its YAML config
+    base_dirs = _load_base_dirs()
+    base_dir = base_dirs.get(dataset_key)
+    if base_dir is None:
+        print(f"  No dataset config found for '{dataset_key}'")
         return
 
     # Step 1: Query to get manifest with all metadata
@@ -92,7 +112,7 @@ def demo_mode_a_expert(client):
     # Step 2: Load data directly from HDF5
     print("\nStep 2: Load data directly from HDF5 (no Tiled)")
     t0 = time.perf_counter()
-    arrays = load_artifacts(manifest, artifact_type=artifact_type)
+    arrays = load_artifacts(manifest, artifact_type=artifact_type, base_dir=base_dir)
     load_time = (time.perf_counter() - t0) * 1000
     print(f"  Loaded {len(arrays)} arrays in {load_time:.1f} ms")
     if arrays:
@@ -126,7 +146,7 @@ def demo_mode_b_visualizer(client):
     print()
 
     # Navigate to dataset-level container (root -> dataset containers -> entities)
-    dataset_client = _find_dataset_container(client, "mh_powder_30T")
+    _, dataset_client = _find_dataset_container(client, "mh_powder_30T")
     if dataset_client is None:
         print("No dataset with mh_powder_30T found!")
         return
@@ -182,16 +202,21 @@ def demo_same_data_two_modes(client):
     """
     import h5py
 
-    base_dir = get_base_dir()
-
     print("\n" + "=" * 60)
     print("SAME DATA, TWO ACCESS PATTERNS")
     print("=" * 60)
 
     # Navigate to dataset-level container (root -> dataset containers -> entities)
-    dataset_client = _find_dataset_container(client, "mh_powder_30T")
+    dataset_key, dataset_client = _find_dataset_container(client, "mh_powder_30T")
     if dataset_client is None:
         print("No dataset with mh_powder_30T found!")
+        return
+
+    # Load base_dir for this dataset
+    base_dirs = _load_base_dirs()
+    base_dir = base_dirs.get(dataset_key)
+    if base_dir is None:
+        print(f"  No dataset config found for '{dataset_key}'")
         return
 
     ent_key = list(dataset_client.keys())[0]

--- a/tiled_poc/examples/demo_ins_dataset_with_query.py
+++ b/tiled_poc/examples/demo_ins_dataset_with_query.py
@@ -191,8 +191,9 @@ def _(mo):
     # Query Tiled for metadata → get HDF5 paths → load directly
     for ent_key, h in subset.items():
         path = h.metadata["path_ins_12meV"]
-        with h5py.File(path, "r") as f:
-            spectrum = f["data"][:]
+        dataset = h.metadata["dataset_ins_12meV"]
+        with h5py.File(base_dir + "/" + path, "r") as f:
+            spectrum = f[dataset][:]
     ```
     """)
     return
@@ -202,14 +203,28 @@ def _(mo):
 def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
     import h5py
     import os
-    from broker.config import get_base_dir, get_dataset_paths
+    from pathlib import Path as _Path
+    from ruamel.yaml import YAML as _YAML
+
+    # Load base_dir from the INS dataset's YAML config
+    _yaml = _YAML()
+    _datasets_dir = _Path(__file__).parent.parent / "datasets"
+    _base_dirs = {}
+    for _cfg_path in sorted(_datasets_dir.glob("*.yaml")):
+        with open(_cfg_path) as _f:
+            _cfg = _yaml.load(_f)
+        _base_dirs[_cfg["key"]] = _cfg["base_dir"]
+
+    # Find which dataset key the subset belongs to (INS dataset)
+    _first_key = list(subset.keys())[0]
+    _first_meta = subset[_first_key].metadata
+    _dataset_key = _first_meta.get("key", None)
 
     def load_ins_mode_a(tiled_client, *, Ei_meV=12, max_spectra=None):
         """Load INS spectra using Mode A (direct HDF5)."""
-        base_dir = get_base_dir()
-        dataset_path = get_dataset_paths()["ins_powder"]  # "/ins/broadened"
         artifact_key = f"ins_{int(Ei_meV)}meV"
         path_key = f"path_{artifact_key}"
+        dataset_key = f"dataset_{artifact_key}"
 
         spectra_list = []
         params_list = []
@@ -219,12 +234,17 @@ def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
                 break
 
             path_rel = h.metadata.get(path_key)
-            if not path_rel:
+            h5_dataset = h.metadata.get(dataset_key)
+            if not path_rel or not h5_dataset:
                 continue
+
+            # Resolve base_dir from the entity's dataset_key metadata
+            ent_dataset_key = h.metadata.get("key")
+            base_dir = _base_dirs.get(ent_dataset_key, "")
 
             path = os.path.join(base_dir, path_rel)
             with h5py.File(path, "r") as f:
-                spectrum = f[dataset_path][:]
+                spectrum = f[h5_dataset][:]
 
             spectra_list.append(spectrum)
             params_list.append([

--- a/tiled_poc/examples/demo_ins_dataset_with_query.py
+++ b/tiled_poc/examples/demo_ins_dataset_with_query.py
@@ -200,13 +200,13 @@ def _(mo):
 
 
 @app.cell
-def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
+def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, client, mo, np, subset, time):
     import h5py
     import os
     from pathlib import Path as _Path
     from ruamel.yaml import YAML as _YAML
 
-    # Load base_dir from the INS dataset's YAML config
+    # Load base_dir from each dataset YAML config
     _yaml = _YAML()
     _datasets_dir = _Path(__file__).parent.parent / "datasets"
     _base_dirs = {}
@@ -215,12 +215,16 @@ def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
             _cfg = _yaml.load(_f)
         _base_dirs[_cfg["key"]] = _cfg["base_dir"]
 
-    # Find which dataset key the subset belongs to (INS dataset)
-    _first_key = list(subset.keys())[0]
-    _first_meta = subset[_first_key].metadata
-    _dataset_key = _first_meta.get("key", None)
+    # Find the INS dataset container to get its base_dir
+    _ins_base_dir = None
+    for _dk in client.keys():
+        _ds = client[_dk]
+        _ents = list(_ds.keys())[:1]
+        if _ents and f"path_ins_{INCIDENT_ENERGY_MEV}meV" in dict(_ds[_ents[0]].metadata):
+            _ins_base_dir = _base_dirs.get(_dk)
+            break
 
-    def load_ins_mode_a(tiled_client, *, Ei_meV=12, max_spectra=None):
+    def load_ins_mode_a(tiled_client, base_dir, *, Ei_meV=12, max_spectra=None):
         """Load INS spectra using Mode A (direct HDF5)."""
         artifact_key = f"ins_{int(Ei_meV)}meV"
         path_key = f"path_{artifact_key}"
@@ -238,10 +242,6 @@ def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
             if not path_rel or not h5_dataset:
                 continue
 
-            # Resolve base_dir from the entity's dataset_key metadata
-            ent_dataset_key = h.metadata.get("key")
-            base_dir = _base_dirs.get(ent_dataset_key, "")
-
             path = os.path.join(base_dir, path_rel)
             with h5py.File(path, "r") as f:
                 spectrum = f[h5_dataset][:]
@@ -258,7 +258,7 @@ def _(INCIDENT_ENERGY_MEV, MAX_SPECTRA_DEMO, mo, np, subset, time):
         return np.stack(spectra_list), np.array(params_list, dtype=np.float32)
 
     _t0 = time.perf_counter()
-    spectra_a, params_a = load_ins_mode_a(subset, Ei_meV=INCIDENT_ENERGY_MEV, max_spectra=MAX_SPECTRA_DEMO)
+    spectra_a, params_a = load_ins_mode_a(subset, _ins_base_dir, Ei_meV=INCIDENT_ENERGY_MEV, max_spectra=MAX_SPECTRA_DEMO)
     time_a = (time.perf_counter() - _t0) * 1000
 
     mo.md(f"""

--- a/tiled_poc/tests/test_config.py
+++ b/tiled_poc/tests/test_config.py
@@ -42,7 +42,6 @@ class TestLoadConfig:
         from broker.config import load_config
         cfg = load_config()
         assert isinstance(cfg, dict)
-        assert "data_dir" in cfg
         assert "service_dir" in cfg
 
     def test_no_manifests_section(self):
@@ -62,55 +61,6 @@ class TestLoadConfig:
         from broker.config import load_config
         cfg = load_config()
         assert "default_shapes" not in cfg
-
-
-class TestGetBaseDir:
-    """Tests for get_base_dir()."""
-
-    def test_returns_string(self):
-        from broker.config import get_base_dir
-        base = get_base_dir()
-        assert isinstance(base, str)
-
-    def test_contains_schema_version(self):
-        from broker.config import get_base_dir
-        base = get_base_dir()
-        assert "schema_v1" in base
-
-    def test_contains_data_path(self):
-        from broker.config import get_base_dir
-        base = get_base_dir()
-        assert "/data/" in base
-
-
-class TestGetLatestManifest:
-    """Tests for get_latest_manifest()."""
-
-    @pytest.mark.skip(reason="requires pre-built manifests in manifests/")
-    def test_finds_entities_manifest(self):
-        from broker.config import get_latest_manifest
-        path = get_latest_manifest("entities")
-        assert path.endswith(".parquet")
-        assert os.path.exists(path)
-
-    @pytest.mark.skip(reason="requires pre-built manifests in manifests/")
-    def test_finds_artifacts_manifest(self):
-        from broker.config import get_latest_manifest
-        path = get_latest_manifest("artifacts")
-        assert path.endswith(".parquet")
-        assert os.path.exists(path)
-
-    def test_raises_for_invalid_prefix(self):
-        from broker.config import get_latest_manifest
-        with pytest.raises(FileNotFoundError):
-            get_latest_manifest("nonexistent_prefix")
-
-    def test_fallback_pattern_is_generic(self):
-        """Without manifests config, fallback uses manifest_{prefix}_*.parquet."""
-        from broker.config import get_latest_manifest, get_base_dir
-        # The fallback pattern should be generic (no dataset-specific names)
-        with pytest.raises(FileNotFoundError, match="manifest_entities_"):
-            get_latest_manifest("entities")
 
 
 class TestGetMaxEntities:

--- a/tiled_poc/tests/test_data_retrieval.py
+++ b/tiled_poc/tests/test_data_retrieval.py
@@ -33,9 +33,28 @@ from pathlib import Path
 import pytest
 import numpy as np
 import h5py
+from ruamel.yaml import YAML
 
 # Add tiled_poc directory to path for broker package imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _load_base_dirs():
+    """Load base_dir from each dataset YAML config in datasets/."""
+    yaml = YAML()
+    base_dirs = {}
+    datasets_dir = Path(__file__).parent.parent / "datasets"
+    for cfg_path in sorted(datasets_dir.glob("*.yaml")):
+        with open(cfg_path) as f:
+            cfg = yaml.load(f)
+        base_dirs[cfg["key"]] = cfg["base_dir"]
+    return base_dirs
+
+
+@pytest.fixture(scope="session")
+def base_dirs():
+    """Load base_dir for each dataset from YAML configs."""
+    return _load_base_dirs()
 
 
 @pytest.mark.integration
@@ -93,22 +112,33 @@ class TestModeAQueryCatalog:
         assert len(manifest) > 0
         assert all(manifest["Ja_meV"] >= 0)
 
-    def test_load_artifacts_returns_arrays(self, small_manifest):
+    def test_load_artifacts_returns_arrays(self, small_manifest, base_dirs):
         """Test that load_artifacts returns a list of numpy arrays."""
         from broker.query_manifest import load_artifacts
 
-        arrays = load_artifacts(small_manifest, artifact_type="mh_powder_30T")
+        # Find the base_dir for the MH dataset
+        mh_base_dir = base_dirs.get("GenericSpin_Sunny_MH")
+        if mh_base_dir is None:
+            pytest.skip("No dataset config found for GenericSpin_Sunny_MH")
+
+        arrays = load_artifacts(small_manifest, artifact_type="mh_powder_30T",
+                                base_dir=mh_base_dir)
 
         assert len(arrays) == len(small_manifest)
         for arr in arrays:
             assert isinstance(arr, np.ndarray)
             assert arr.ndim >= 1
 
-    def test_load_artifacts_correct_shape(self, small_manifest):
+    def test_load_artifacts_correct_shape(self, small_manifest, base_dirs):
         """Test that loaded M(H) arrays have expected shape."""
         from broker.query_manifest import load_artifacts
 
-        arrays = load_artifacts(small_manifest, artifact_type="mh_powder_30T")
+        mh_base_dir = base_dirs.get("GenericSpin_Sunny_MH")
+        if mh_base_dir is None:
+            pytest.skip("No dataset config found for GenericSpin_Sunny_MH")
+
+        arrays = load_artifacts(small_manifest, artifact_type="mh_powder_30T",
+                                base_dir=mh_base_dir)
 
         for arr in arrays:
             assert arr.shape == (200,)  # M(H) has 200 field points
@@ -185,9 +215,11 @@ class TestModeBTiledAdapter:
 class TestModeAModeBEquivalence:
     """Tests verifying both modes return identical data."""
 
-    def test_mh_curve_data_matches(self, mh_dataset_client):
+    def test_mh_curve_data_matches(self, mh_dataset_client, base_dirs):
         """Test that Mode A and Mode B return same M(H) data."""
-        from broker.config import get_base_dir
+        mh_base_dir = base_dirs.get("GenericSpin_Sunny_MH")
+        if mh_base_dir is None:
+            pytest.skip("No dataset config found for GenericSpin_Sunny_MH")
 
         ent_key = list(mh_dataset_client.keys())[0]
         h = mh_dataset_client[ent_key]
@@ -204,17 +236,18 @@ class TestModeAModeBEquivalence:
         if not path_rel or not dataset_path:
             pytest.skip("Locator metadata not available")
 
-        base_dir = get_base_dir()
-        path = os.path.join(base_dir, path_rel)
+        path = os.path.join(mh_base_dir, path_rel)
 
         with h5py.File(path, "r") as f:
             mode_a_data = f[dataset_path][:]
 
         assert np.allclose(mode_a_data, mode_b_data), "Mode A and Mode B data mismatch!"
 
-    def test_metadata_matches_hdf5(self, mh_dataset_client):
+    def test_metadata_matches_hdf5(self, mh_dataset_client, base_dirs):
         """Test that metadata matches values in HDF5 files."""
-        from broker.config import get_base_dir
+        mh_base_dir = base_dirs.get("GenericSpin_Sunny_MH")
+        if mh_base_dir is None:
+            pytest.skip("No dataset config found for GenericSpin_Sunny_MH")
 
         ent_key = list(mh_dataset_client.keys())[0]
         h = mh_dataset_client[ent_key]
@@ -223,7 +256,6 @@ class TestModeAModeBEquivalence:
         if not path_rel:
             pytest.skip("No path metadata available")
 
-        base_dir = get_base_dir()
-        path = os.path.join(base_dir, path_rel)
+        path = os.path.join(mh_base_dir, path_rel)
 
         assert os.path.exists(path), f"HDF5 file not found: {path}"


### PR DESCRIPTION
## Summary
- Remove `get_base_dir()` and `get_latest_manifest()` from `config.py` — VDP-era relics that hardcoded a single `base_dir` path pattern (`{data_dir}/data/{schema_version}`)
- Make `base_dir` a required parameter in `load_artifacts()` and `prepare_node_data()` — callers must be explicit
- Remove standalone `main()` from `bulk_register.py` (superseded by `cli.py` entry points)
- Fix broken `get_dataset_paths()` call in `demo_ins_dataset_with_query.py`
- Remove `data_dir` and `schema_version` from `config.yml` (no longer consumed)

**8 files changed, net -182 lines (118 added, 300 removed)**

## Test plan
- [x] 51 unit tests pass (`test_config.py`, `test_utils.py`, `test_generic_registration.py`)
- [ ] Integration tests on SDF with running Tiled server
- [ ] Verify `broker-ingest` and `broker-register` CLI commands still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)