### PR TITLE
feat: add onboarding pipeline (inspect, generate, schema)

### DIFF
--- a/tiled_poc/broker/cli.py
+++ b/tiled_poc/broker/cli.py
@@ -1,9 +1,11 @@
 """
 CLI entry points for the broker package.
 
-Provides two commands:
-  - broker-ingest:    Bulk SQL registration from Parquet manifests
-  - broker-register:  HTTP registration against a running Tiled server
+Provides four commands:
+  - broker-inspect:    Auto-scan HDF5 directory and emit draft YAML config
+  - broker-generate:   Generate Parquet manifests from a dataset YAML config
+  - broker-ingest:     Bulk SQL registration from Parquet manifests
+  - broker-register:   HTTP registration against a running Tiled server
 
 All paths (catalog.db, manifests/, storage/, datasets/) are resolved
 relative to the current working directory.
@@ -27,7 +29,31 @@ def _load_config(config_path):
         return yaml.load(f)
 
 
-# ── broker-ingest ────────────────────────────────────────────────
+# -- broker-inspect ---------------------------------------------------
+
+def inspect_main():
+    """Auto-scan an HDF5 data directory and emit a draft YAML config.
+
+    Detects layout (per_entity, batched, grouped), classifies datasets,
+    and writes a draft YAML with TODO markers for the user to complete.
+    """
+    from broker.onboarding.inspect import main as _inspect_main
+    _inspect_main()
+
+
+# -- broker-generate --------------------------------------------------
+
+def generate_main():
+    """Generate Parquet manifests from a finalized dataset YAML config.
+
+    Reads the YAML contract, validates it against the catalog model,
+    and produces entities.parquet + artifacts.parquet.
+    """
+    from broker.onboarding.generate import main as _generate_main
+    _generate_main()
+
+
+# -- broker-ingest ----------------------------------------------------
 
 def ingest_main():
     """Bulk SQL registration (from ingest.py).
@@ -96,7 +122,7 @@ def ingest_main():
     print("\nDone!")
 
 
-# ── broker-register ──────────────────────────────────────────────
+# -- broker-register --------------------------------------------------
 
 def register_main():
     """HTTP registration against a running Tiled server (from register.py).

--- a/tiled_poc/broker/onboarding/__init__.py
+++ b/tiled_poc/broker/onboarding/__init__.py
@@ -1,0 +1,31 @@
+"""
+Onboarding pipeline for registering new HDF5 datasets.
+
+Provides three capabilities:
+  - inspect: Auto-scan HDF5 directories, detect layout, emit draft YAML config
+  - generate: Produce Parquet manifests from finalized YAML configs
+  - schema: Validate YAML configs against a controlled vocabulary
+
+Typical workflow:
+    from broker.onboarding.inspect import inspect_directory, emit_draft_yaml
+    from broker.onboarding.generate import generate_manifests
+    from broker.onboarding.schema import validate
+
+    result = inspect_directory("/path/to/hdf5/data")
+    emit_draft_yaml(result, "datasets/draft.yml")
+    # ... user edits draft.yml ...
+    warnings = validate(config)
+    ent_path, art_path = generate_manifests("datasets/mydata.yml")
+"""
+
+from .inspect import inspect_directory, emit_draft_yaml
+from .generate import generate_manifests
+from .schema import validate, ValidationError
+
+__all__ = [
+    "inspect_directory",
+    "emit_draft_yaml",
+    "generate_manifests",
+    "validate",
+    "ValidationError",
+]

--- a/tiled_poc/broker/onboarding/generate.py
+++ b/tiled_poc/broker/onboarding/generate.py
@@ -1,0 +1,554 @@
+"""
+Generic manifest generator.
+
+Reads a finalized YAML contract and produces Parquet manifests
+(entities.parquet and artifacts.parquet) for Tiled registration.
+
+The output manifests follow the broker standard:
+  Entity manifest:  uid, key, <param_1>, <param_2>, ...
+  Artifact manifest: uid (= entity uid), type, file, dataset, [index]
+
+Handles three layout patterns:
+  - per_entity: one HDF5 file per entity, scalars are parameters
+  - batched: entities stacked along axis-0 of datasets in each file
+  - grouped: one HDF5 group per entity inside a single file
+
+Supports five parameter locations:
+  - root_scalars: scalar HDF5 datasets at file root
+  - root_attributes: HDF5 root-level file attributes (f.attrs)
+  - group: datasets inside a named HDF5 group (e.g., /params)
+  - group_scalars: scalars inside entity groups (grouped layout)
+  - manifest: external CSV or Parquet file with parameter columns
+
+Usage:
+    dcs generate datasets/edrixs_sbi.yml
+    dcs generate datasets/edrixs_sbi.yml --append
+"""
+
+import os
+import sys
+import hashlib
+import datetime
+from pathlib import Path
+from collections import OrderedDict
+
+import h5py
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from ruamel.yaml import YAML
+
+from .schema import validate, ValidationError
+
+
+# Columns in external parameter manifests that are not physics parameters.
+_PARAM_MANIFEST_SKIP_COLS = {"file", "filename", "sample_idx", "output_file"}
+
+
+def load_yaml(yaml_path):
+    """Load and validate a dataset YAML config."""
+    yaml = YAML()
+    with open(yaml_path) as f:
+        cfg = yaml.load(f)
+    warnings = validate(cfg)
+    for w in warnings:
+        print(f"  Warning: {w}")
+    return cfg
+
+
+def compute_config_hash(yaml_path):
+    """Compute SHA256 hash of a YAML config file's content."""
+    with open(yaml_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def _file_fingerprint(path):
+    """Return (size_bytes, mtime_iso) for a file path."""
+    stat = os.stat(path)
+    mtime = datetime.datetime.fromtimestamp(
+        stat.st_mtime, tz=datetime.timezone.utc
+    ).isoformat()
+    return stat.st_size, mtime
+
+
+def generate_manifests(yaml_path, output_dir=None, append=False):
+    """Generate entity and artifact manifests from a YAML config.
+
+    Args:
+        yaml_path: Path to the finalized YAML config.
+        output_dir: Directory for output Parquet files (default: manifests/<label>/).
+        append: If True, skip entities already in existing manifests and
+            merge new entities with the existing ones.
+
+    Returns:
+        (str, str): Paths to entities.parquet and artifacts.parquet.
+    """
+    cfg = load_yaml(yaml_path)
+    config_hash = compute_config_hash(yaml_path)
+
+    label = cfg["label"]
+    key_prefix = cfg.get("key", cfg.get("key_prefix", label))
+    data = cfg["data"]
+    directory = data["directory"]
+    file_pattern = data.get("file_pattern", "**/*.h5")
+    layout = data["layout"]
+
+    if output_dir is None:
+        output_dir = os.path.join(os.path.dirname(yaml_path) or ".", "manifests", label)
+    os.makedirs(output_dir, exist_ok=True)
+
+    artifacts_cfg = cfg.get("artifacts", [])
+    shared_cfg = cfg.get("shared", [])
+    params_cfg = cfg.get("parameters", {})
+    extra_meta_cfg = cfg.get("extra_metadata", [])
+
+    # Load external parameter manifest if location is "manifest"
+    param_manifest = None
+    if params_cfg.get("location") == "manifest":
+        mpath = params_cfg["manifest"]
+        if not os.path.isabs(mpath):
+            mpath = os.path.join(directory, mpath)
+        if mpath.endswith(".csv"):
+            param_manifest = pd.read_csv(mpath)
+        else:
+            param_manifest = pd.read_parquet(mpath)
+        print(f"  Loaded parameter manifest: {mpath} ({len(param_manifest)} rows)")
+
+    # Load existing UIDs for append mode
+    existing_uids = set()
+    if append:
+        existing_ent_path = os.path.join(output_dir, "entities.parquet")
+        if os.path.exists(existing_ent_path):
+            existing_df = pd.read_parquet(existing_ent_path, columns=["uid"])
+            existing_uids = set(existing_df["uid"])
+            print(f"  Append mode: {len(existing_uids)} existing entities will be skipped")
+
+    # Find HDF5 files
+    root = Path(directory)
+    h5_files = sorted(root.glob(file_pattern))
+    if not h5_files:
+        h5_files = sorted(root.rglob(file_pattern))
+    if not h5_files:
+        print(f"Error: No HDF5 files matching '{file_pattern}' in {directory}")
+        sys.exit(1)
+    print(f"Found {len(h5_files)} HDF5 files")
+
+    if layout == "per_entity":
+        ent_rows, art_rows = _generate_per_entity(
+            h5_files, root, key_prefix, artifacts_cfg, shared_cfg,
+            params_cfg, extra_meta_cfg, cfg, param_manifest, existing_uids,
+        )
+    elif layout == "batched":
+        ent_rows, art_rows = _generate_batched(
+            h5_files, root, key_prefix, artifacts_cfg, shared_cfg,
+            params_cfg, extra_meta_cfg, cfg, param_manifest, existing_uids,
+        )
+    elif layout == "grouped":
+        ent_rows, art_rows = _generate_grouped(
+            h5_files, root, key_prefix, artifacts_cfg, shared_cfg,
+            params_cfg, extra_meta_cfg, cfg, param_manifest, existing_uids,
+        )
+    else:
+        print(f"Error: Unknown layout '{layout}'")
+        sys.exit(1)
+
+    # Build DataFrames
+    ent_df = pd.DataFrame(ent_rows)
+    art_df = pd.DataFrame(art_rows)
+
+    # In append mode, merge with existing manifests
+    if append and existing_uids:
+        old_ent_path = os.path.join(output_dir, "entities.parquet")
+        old_art_path = os.path.join(output_dir, "artifacts.parquet")
+        if os.path.exists(old_ent_path) and os.path.exists(old_art_path):
+            old_ent = pd.read_parquet(old_ent_path)
+            old_art = pd.read_parquet(old_art_path)
+            ent_df = pd.concat([old_ent, ent_df], ignore_index=True)
+            art_df = pd.concat([old_art, art_df], ignore_index=True)
+            print(f"  Merged: {len(old_ent)} existing + {len(ent_rows)} new entities")
+
+    # Write Parquet with provenance metadata
+    ent_path = os.path.join(output_dir, "entities.parquet")
+    art_path = os.path.join(output_dir, "artifacts.parquet")
+
+    generation_meta = {
+        b"generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat().encode(),
+        b"generator": b"broker-generate-yaml",
+        b"source_yaml": os.path.basename(str(yaml_path)).encode(),
+        b"config_hash": config_hash.encode(),
+        b"layout": layout.encode(),
+        b"entity_count": str(len(ent_df)).encode(),
+        b"artifact_count": str(len(art_df)).encode(),
+    }
+
+    ent_table = pa.Table.from_pandas(ent_df)
+    ent_table = ent_table.replace_schema_metadata(
+        {**(ent_table.schema.metadata or {}), **generation_meta}
+    )
+    pq.write_table(ent_table, ent_path)
+
+    art_table = pa.Table.from_pandas(art_df)
+    art_table = art_table.replace_schema_metadata(
+        {**(art_table.schema.metadata or {}), **generation_meta}
+    )
+    pq.write_table(art_table, art_path)
+
+    print(f"Entities: {len(ent_df)} rows -> {ent_path}")
+    print(f"Artifacts: {len(art_df)} rows -> {art_path}")
+
+    return ent_path, art_path
+
+
+# ---------------------------------------------------------------------------
+# Per-entity layout
+# ---------------------------------------------------------------------------
+
+def _generate_per_entity(h5_files, root, key_prefix, artifacts_cfg,
+                         shared_cfg, params_cfg, extra_meta_cfg, cfg,
+                         param_manifest=None, existing_uids=None):
+    """One HDF5 file = one entity. Scalars at root are parameters."""
+    ent_rows = []
+    art_rows = []
+    if existing_uids is None:
+        existing_uids = set()
+
+    # Cache file fingerprints to avoid repeated stat calls
+    _fingerprint_cache = {}
+
+    for i, h5_path in enumerate(h5_files):
+        rel_path = str(h5_path.relative_to(root))
+        file_stem = h5_path.stem
+        uid = _make_uid(f"{key_prefix}_{file_stem}")
+
+        if uid in existing_uids:
+            continue
+
+        # Cache fingerprint per file
+        if rel_path not in _fingerprint_cache:
+            _fingerprint_cache[rel_path] = _file_fingerprint(h5_path)
+
+        entity_key = f"H_{uid[:8]}"
+
+        entity_row = OrderedDict()
+        entity_row["uid"] = uid
+        entity_row["key"] = entity_key
+
+        loc = params_cfg.get("location", "root_scalars")
+
+        if loc == "manifest" and param_manifest is not None:
+            # Match by file stem in first column, or by index
+            first_col = param_manifest.columns[0]
+            match = param_manifest[
+                param_manifest[first_col].astype(str) == file_stem
+            ]
+            if not match.empty:
+                row = match.iloc[0]
+                for col in param_manifest.columns:
+                    if col not in _PARAM_MANIFEST_SKIP_COLS:
+                        val = row[col]
+                        if pd.notna(val):
+                            entity_row[col] = _to_python(val)
+        else:
+            with h5py.File(h5_path, "r") as f:
+                if loc == "root_scalars":
+                    for ds_name in sorted(f.keys()):
+                        ds = f[ds_name]
+                        if isinstance(ds, h5py.Dataset) and ds.ndim == 0:
+                            entity_row[ds_name] = _to_python(ds[()])
+                elif loc == "root_attributes":
+                    for attr_name in sorted(f.attrs.keys()):
+                        entity_row[attr_name] = _to_python(f.attrs[attr_name])
+                elif loc == "group":
+                    group_name = params_cfg["group"].lstrip("/")
+                    if group_name in f:
+                        for pname in sorted(f[group_name].keys()):
+                            ds = f[group_name][pname]
+                            if isinstance(ds, h5py.Dataset):
+                                entity_row[pname] = _to_python(ds[()])
+
+                # Extra metadata datasets
+                for extra in extra_meta_cfg:
+                    ds_path = extra["dataset"].lstrip("/")
+                    if ds_path in f:
+                        ds = f[ds_path]
+                        if isinstance(ds, h5py.Dataset):
+                            if ds.ndim == 0:
+                                entity_row[ds_path] = _to_python(ds[()])
+                            elif ds.ndim == 1 and ds.size <= 10:
+                                entity_row[ds_path] = ds[:].tolist()
+
+        ent_rows.append(entity_row)
+
+        # Artifact rows — uid matches entity uid for groupby in bulk_register
+        fsize, fmtime = _fingerprint_cache[rel_path]
+        for art in artifacts_cfg:
+            art_row = OrderedDict()
+            art_row["uid"] = uid
+            art_row["type"] = art["type"]
+            art_row["file"] = rel_path
+            art_row["dataset"] = art["dataset"]
+            art_row["index"] = None
+            art_row["file_size"] = fsize
+            art_row["file_mtime"] = fmtime
+            art_rows.append(art_row)
+
+        if (i + 1) % 1000 == 0:
+            print(f"  Processed {i + 1}/{len(h5_files)} entities...")
+
+    return ent_rows, art_rows
+
+
+# ---------------------------------------------------------------------------
+# Batched layout
+# ---------------------------------------------------------------------------
+
+def _generate_batched(h5_files, root, key_prefix, artifacts_cfg,
+                      shared_cfg, params_cfg, extra_meta_cfg, cfg,
+                      param_manifest=None, existing_uids=None):
+    """Multiple entities stacked along axis-0 in each file."""
+    ent_rows = []
+    art_rows = []
+    global_idx = 0
+    if existing_uids is None:
+        existing_uids = set()
+
+    for h5_path in h5_files:
+        rel_path = str(h5_path.relative_to(root))
+        fsize, fmtime = _file_fingerprint(h5_path)
+
+        with h5py.File(h5_path, "r") as f:
+            # Determine batch size from first artifact
+            first_art_ds = artifacts_cfg[0]["dataset"].lstrip("/")
+            batch_size = f[first_art_ds].shape[0]
+
+            # Read all parameters at once
+            param_arrays = {}
+            loc = params_cfg.get("location", "group")
+            if loc == "group":
+                group_name = params_cfg["group"].lstrip("/")
+                if group_name in f:
+                    for pname in sorted(f[group_name].keys()):
+                        param_arrays[pname] = f[group_name][pname][:]
+            elif loc == "root_scalars":
+                for ds_name in sorted(f.keys()):
+                    ds = f[ds_name]
+                    if isinstance(ds, h5py.Dataset) and ds.ndim == 1 and ds.shape[0] == batch_size:
+                        param_arrays[ds_name] = ds[:]
+            elif loc == "root_attributes":
+                # Attributes are scalars — same value for all entities in batch
+                root_attr_params = {
+                    attr_name: _to_python(f.attrs[attr_name])
+                    for attr_name in sorted(f.attrs.keys())
+                }
+            # loc == "manifest" handled below per-entity
+
+            # Read extra metadata arrays
+            extra_arrays = {}
+            for extra in extra_meta_cfg:
+                ds_path = extra["dataset"].lstrip("/")
+                if ds_path in f:
+                    ds = f[ds_path]
+                    if isinstance(ds, h5py.Dataset) and ds.ndim >= 1 and ds.shape[0] == batch_size:
+                        extra_arrays[ds_path] = ds[:]
+
+            for i in range(batch_size):
+                uid = _make_uid(f"{key_prefix}_{global_idx:06d}")
+
+                if uid in existing_uids:
+                    global_idx += 1
+                    continue
+
+                entity_key = f"H_{uid[:8]}"
+
+                entity_row = OrderedDict()
+                entity_row["uid"] = uid
+                entity_row["key"] = entity_key
+
+                if loc == "manifest" and param_manifest is not None:
+                    pm_idx = global_idx
+                    if pm_idx < len(param_manifest):
+                        row = param_manifest.iloc[pm_idx]
+                        for col in param_manifest.columns:
+                            if col not in _PARAM_MANIFEST_SKIP_COLS:
+                                val = row[col]
+                                if pd.notna(val):
+                                    entity_row[col] = _to_python(val)
+                elif loc == "root_attributes":
+                    entity_row.update(root_attr_params)
+                else:
+                    for pname, arr in param_arrays.items():
+                        entity_row[pname] = _to_python(arr[i])
+
+                # Extra metadata
+                for ds_path, arr in extra_arrays.items():
+                    col_name = ds_path.rsplit("/", 1)[-1]
+                    if arr.ndim == 1:
+                        entity_row[col_name] = _to_python(arr[i])
+                    elif arr.ndim > 1:
+                        entity_row[col_name] = arr[i].tolist()
+
+                ent_rows.append(entity_row)
+
+                # Artifact rows — uid matches entity uid
+                for art in artifacts_cfg:
+                    art_row = OrderedDict()
+                    art_row["uid"] = uid
+                    art_row["type"] = art["type"]
+                    art_row["file"] = rel_path
+                    art_row["dataset"] = art["dataset"]
+                    art_row["index"] = i
+                    art_row["file_size"] = fsize
+                    art_row["file_mtime"] = fmtime
+                    art_rows.append(art_row)
+
+                global_idx += 1
+
+        print(f"  Processed {h5_path.name}: {batch_size} entities (total: {global_idx})")
+
+    return ent_rows, art_rows
+
+
+# ---------------------------------------------------------------------------
+# Grouped layout
+# ---------------------------------------------------------------------------
+
+def _generate_grouped(h5_files, root, key_prefix, artifacts_cfg,
+                      shared_cfg, params_cfg, extra_meta_cfg, cfg,
+                      param_manifest=None, existing_uids=None):
+    """One HDF5 group per entity inside a file."""
+    ent_rows = []
+    art_rows = []
+    global_idx = 0
+    if existing_uids is None:
+        existing_uids = set()
+
+    entity_group = params_cfg.get("entity_group", "samples")
+
+    for h5_path in h5_files:
+        rel_path = str(h5_path.relative_to(root))
+        fsize, fmtime = _file_fingerprint(h5_path)
+
+        with h5py.File(h5_path, "r") as f:
+            if entity_group in f and isinstance(f[entity_group], h5py.Group):
+                group_keys = sorted(f[entity_group].keys())
+                base_group = entity_group
+            else:
+                group_keys = [k for k in sorted(f.keys()) if isinstance(f[k], h5py.Group)]
+                base_group = ""
+
+            for gkey in group_keys:
+                full_group = f"{base_group}/{gkey}" if base_group else gkey
+                g = f[full_group]
+
+                uid = _make_uid(f"{key_prefix}_{global_idx:06d}")
+
+                if uid in existing_uids:
+                    global_idx += 1
+                    continue
+
+                entity_key = f"H_{uid[:8]}"
+
+                entity_row = OrderedDict()
+                entity_row["uid"] = uid
+                entity_row["key"] = entity_key
+                entity_row["source_group"] = full_group
+
+                # Read parameters from within the group
+                loc = params_cfg.get("location", "group_scalars")
+                if loc == "manifest" and param_manifest is not None:
+                    pm_idx = global_idx
+                    if pm_idx < len(param_manifest):
+                        row = param_manifest.iloc[pm_idx]
+                        for col in param_manifest.columns:
+                            if col not in _PARAM_MANIFEST_SKIP_COLS:
+                                val = row[col]
+                                if pd.notna(val):
+                                    entity_row[col] = _to_python(val)
+                elif loc == "group_scalars":
+                    param_group = params_cfg.get("group", "params")
+                    param_path = param_group.lstrip("/")
+                    if param_path in g and isinstance(g[param_path], h5py.Group):
+                        for pname in sorted(g[param_path].keys()):
+                            ds = g[param_path][pname]
+                            if isinstance(ds, h5py.Dataset):
+                                entity_row[pname] = _to_python(ds[()])
+                    else:
+                        for ds_name in sorted(g.keys()):
+                            ds = g[ds_name]
+                            if isinstance(ds, h5py.Dataset) and ds.ndim == 0:
+                                entity_row[ds_name] = _to_python(ds[()])
+                elif loc == "root_attributes":
+                    for attr_name in sorted(f.attrs.keys()):
+                        entity_row[attr_name] = _to_python(f.attrs[attr_name])
+
+                ent_rows.append(entity_row)
+
+                # Artifact rows
+                for art in artifacts_cfg:
+                    art_type = art["type"]
+                    ds_path = art["dataset"].lstrip("/")
+                    full_ds_path = f"/{full_group}/{ds_path}"
+
+                    art_row = OrderedDict()
+                    art_row["uid"] = uid
+                    art_row["type"] = art_type
+                    art_row["file"] = rel_path
+                    art_row["dataset"] = full_ds_path
+                    art_row["index"] = None
+                    art_row["file_size"] = fsize
+                    art_row["file_mtime"] = fmtime
+                    art_rows.append(art_row)
+
+                global_idx += 1
+
+        print(f"  Processed {h5_path.name}: {len(group_keys)} entity groups (total: {global_idx})")
+
+    return ent_rows, art_rows
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_uid(key_str):
+    """Generate a deterministic UID from a key string."""
+    return hashlib.sha256(key_str.encode()).hexdigest()[:16]
+
+
+def _to_python(val):
+    """Convert numpy/HDF5 value to Python native type."""
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    if isinstance(val, np.generic):
+        return val.item()
+    if isinstance(val, np.ndarray):
+        if val.size == 1:
+            return val.item()
+        return val.tolist()
+    return val
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate Parquet manifests from a dataset YAML contract."
+    )
+    parser.add_argument("yaml_path", help="Path to the finalized dataset YAML config")
+    parser.add_argument("--output-dir", "-o", help="Output directory for manifests")
+    parser.add_argument(
+        "--append", action="store_true",
+        help="Append new entities to existing manifests (skip already-generated UIDs)",
+    )
+    args = parser.parse_args()
+
+    try:
+        generate_manifests(args.yaml_path, args.output_dir, append=args.append)
+    except ValidationError as e:
+        print(f"Validation failed:\n{e}", file=sys.stderr)
+        sys.exit(1)

--- a/tiled_poc/broker/onboarding/inspect.py
+++ b/tiled_poc/broker/onboarding/inspect.py
@@ -1,0 +1,831 @@
+"""
+HDF5 inspection engine for auto-generating dataset contract YAMLs.
+
+Scans a directory of HDF5 files, classifies datasets by role
+(parameter, artifact, shared axis), validates consistency,
+and emits a draft YAML config with TODO markers.
+
+Usage:
+    dcs inspect /path/to/data/ [--output datasets/draft.yml]
+"""
+
+import os
+import sys
+import datetime
+from pathlib import Path
+from collections import Counter
+from dataclasses import dataclass, field
+
+import h5py
+import numpy as np
+
+from .schema import load_catalog_model, get_allowed_values
+
+
+# ---------------------------------------------------------------------------
+# Data classes for inspection results
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DatasetInfo:
+    """Metadata about a single HDF5 dataset."""
+    name: str
+    shape: tuple
+    dtype: str
+    ndim: int
+    size: int
+    category: str = ""  # PARAMETER, ARTIFACT, SHARED_AXIS, EXTRA_METADATA
+    stats: dict = field(default_factory=dict)
+
+
+@dataclass
+class InspectionResult:
+    """Complete inspection results for a data directory."""
+    source_dir: str
+    h5_files: list
+    file_pattern: str
+    layout: str  # per_entity, batched, grouped
+    batch_size: int = 0
+    total_entities: int = 0
+    datasets: dict = field(default_factory=dict)  # name -> DatasetInfo
+    groups: list = field(default_factory=list)
+    root_attrs: dict = field(default_factory=dict)
+    group_attrs: dict = field(default_factory=dict)
+    dataset_attrs: dict = field(default_factory=dict)
+    consistency_issues: list = field(default_factory=list)
+    recommendations: list = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Directory Reconnaissance
+# ---------------------------------------------------------------------------
+
+def find_h5_files(directory):
+    """Find all HDF5 files and infer the glob pattern.
+
+    Returns:
+        (list[Path], str): Sorted HDF5 file paths and inferred glob pattern.
+    """
+    root = Path(directory)
+    h5_files = sorted(root.rglob("*.h5"))
+    if not h5_files:
+        h5_files = sorted(root.rglob("*.hdf5"))
+
+    if not h5_files:
+        return [], "*.h5"
+
+    # Infer file pattern from common structure
+    rel_paths = [f.relative_to(root) for f in h5_files]
+
+    if len(set(f.name for f in rel_paths)) == 1:
+        # All files have the same name (e.g., simulations.h5) — pattern is parent/name
+        sample = rel_paths[0]
+        parts = list(sample.parts)
+        pattern = "/".join(["*"] * (len(parts) - 1) + [parts[-1]])
+    elif all(len(f.parts) == 1 for f in rel_paths):
+        pattern = "*.h5"
+    else:
+        pattern = "**/*.h5"
+
+    return h5_files, pattern
+
+
+# ---------------------------------------------------------------------------
+# Step 2: HDF5 Tree Walk
+# ---------------------------------------------------------------------------
+
+def walk_h5_tree(h5_path):
+    """Walk an HDF5 file and collect all dataset/group metadata.
+
+    Returns:
+        (dict[str, DatasetInfo], list[str]): datasets and group names.
+    """
+    datasets = {}
+    groups = []
+
+    with h5py.File(h5_path, "r") as f:
+        def visit(name, obj):
+            if isinstance(obj, h5py.Dataset):
+                datasets[name] = DatasetInfo(
+                    name=name,
+                    shape=obj.shape,
+                    dtype=str(obj.dtype),
+                    ndim=obj.ndim,
+                    size=obj.size,
+                )
+            elif isinstance(obj, h5py.Group):
+                groups.append(name)
+
+        f.visititems(visit)
+
+    return datasets, groups
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Classify Datasets
+# ---------------------------------------------------------------------------
+
+def classify_datasets(datasets, groups, layout, batch_size=0):
+    """Classify each dataset as PARAMETER, ARTIFACT, SHARED_AXIS, or EXTRA_METADATA."""
+    # Identify parameter groups (groups that contain per-entity 1D arrays)
+    param_groups = set()
+    if layout == "batched":
+        for g in groups:
+            children = [n for n in datasets if n.startswith(g + "/")]
+            if children and all(
+                datasets[n].ndim == 1 and datasets[n].shape[0] == batch_size
+                for n in children
+            ):
+                param_groups.add(g)
+
+    for name, ds in datasets.items():
+        if layout == "per_entity":
+            if ds.ndim == 0:
+                ds.category = "PARAMETER"
+            else:
+                ds.category = "ARTIFACT_OR_AXIS"
+
+        elif layout == "batched":
+            parent_group = name.rsplit("/", 1)[0] if "/" in name else ""
+            if ds.shape and ds.shape[0] == batch_size:
+                if ds.ndim == 1 and parent_group in param_groups:
+                    ds.category = "PARAMETER"
+                elif ds.ndim == 1:
+                    ds.category = "EXTRA_METADATA"
+                elif ds.ndim > 1:
+                    ds.category = "ARTIFACT"
+                else:
+                    ds.category = "EXTRA_METADATA"
+            elif ds.ndim == 0:
+                ds.category = "PARAMETER"
+            else:
+                ds.category = "SHARED_AXIS"
+
+        elif layout == "grouped":
+            ds.category = "ARTIFACT_OR_AXIS"
+
+
+def detect_layout(datasets, h5_files):
+    """Detect whether the data is per_entity, batched, or grouped.
+
+    Returns:
+        (str, int): layout type and batch_size (0 if not batched).
+    """
+    if not datasets:
+        return "per_entity", 0
+
+    has_scalars = any(ds.ndim == 0 for ds in datasets.values())
+    many_files = len(h5_files) > 1
+
+    # Key insight: scalars + many files = per_entity.
+    if has_scalars and many_files:
+        return "per_entity", 0
+
+    # Check shapes for batched pattern
+    shapes_with_dim = [(name, ds.shape) for name, ds in datasets.items() if ds.ndim >= 1]
+
+    if not shapes_with_dim:
+        return "per_entity", 0
+
+    axis0_lengths = [s[0] for _, s in shapes_with_dim]
+    counts = Counter(axis0_lengths)
+    most_common_len, most_common_count = counts.most_common(1)[0]
+
+    # Batched if: few files, axis-0 shared by 3+ datasets, and axis-0 is large
+    if most_common_count >= 3 and most_common_len > 1:
+        if not many_files or most_common_len >= 100:
+            return "batched", most_common_len
+
+    if many_files:
+        return "per_entity", 0
+
+    return "per_entity", 0
+
+
+def detect_grouped_layout(h5_path):
+    """Check if a single HDF5 file uses group-per-entity pattern.
+
+    Returns:
+        (bool, list[str]): Whether it's grouped and the list of entity group names.
+    """
+    entity_groups = []
+    with h5py.File(h5_path, "r") as f:
+        for key in f.keys():
+            if isinstance(f[key], h5py.Group):
+                has_datasets = any(isinstance(f[key][k], h5py.Dataset) for k in f[key].keys())
+                if has_datasets:
+                    entity_groups.append(key)
+
+    return len(entity_groups) > 5, entity_groups
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Read Sample Values
+# ---------------------------------------------------------------------------
+
+def read_sample_values(h5_path, datasets, layout, batch_size=0, all_h5_files=None):
+    """Read sample values from each dataset to compute statistics."""
+    with h5py.File(h5_path, "r") as f:
+        for name, ds in datasets.items():
+            try:
+                if ds.category == "PARAMETER":
+                    data = f[name][()] if ds.ndim == 0 else f[name][:]
+                    # For per-entity scalars, sample across multiple files
+                    if layout == "per_entity" and ds.ndim == 0 and all_h5_files and len(all_h5_files) > 1:
+                        sample_files = _sample_files(all_h5_files, n=100)
+                        values = []
+                        for sf in sample_files:
+                            try:
+                                with h5py.File(sf, "r") as g:
+                                    values.append(float(g[name][()]))
+                            except Exception:
+                                pass
+                        if values:
+                            arr = np.array(values)
+                            ds.stats = {
+                                "min": _safe_float(arr.min()),
+                                "max": _safe_float(arr.max()),
+                                "n_unique": int(len(np.unique(arr))),
+                                "has_nans": bool(np.isnan(arr).any()),
+                                "is_constant": bool(arr.min() == arr.max()),
+                                "sampled_from": len(values),
+                            }
+                            continue
+                    flat = np.asarray(data).ravel()
+                    finite = flat[np.isfinite(flat)] if flat.dtype.kind == "f" else flat
+                    ds.stats = {
+                        "min": _safe_float(np.nanmin(data)) if finite.size > 0 else None,
+                        "max": _safe_float(np.nanmax(data)) if finite.size > 0 else None,
+                        "n_unique": int(len(np.unique(finite))) if finite.size > 0 else 0,
+                        "has_nans": bool(np.isnan(data).any()) if data.dtype.kind == "f" else False,
+                        "is_constant": bool(np.nanmin(data) == np.nanmax(data)) if finite.size > 0 else True,
+                    }
+                elif ds.category == "ARTIFACT":
+                    if layout == "batched" and ds.ndim > 1:
+                        sample = f[name][0]
+                    else:
+                        sample = f[name][:]
+                    ds.stats = {
+                        "shape_per_entity": list(sample.shape),
+                        "min": _safe_float(np.nanmin(sample)),
+                        "max": _safe_float(np.nanmax(sample)),
+                        "nan_fraction": float(np.isnan(sample).mean()) if sample.dtype.kind == "f" else 0.0,
+                    }
+                elif ds.category == "SHARED_AXIS":
+                    data = f[name][:]
+                    is_mono = False
+                    if data.ndim == 1 and data.size > 1:
+                        diffs = np.diff(data[:100].astype(float))
+                        is_mono = bool(np.all(diffs > 0) or np.all(diffs < 0))
+                    ds.stats = {
+                        "shape": list(data.shape),
+                        "range": [_safe_float(data.min()), _safe_float(data.max())],
+                        "monotonic": is_mono,
+                    }
+                    if data.ndim == 1 and data.size > 1:
+                        ds.stats["step"] = _safe_float(np.mean(np.diff(data.astype(float))))
+                elif ds.category in ("EXTRA_METADATA", "ARTIFACT_OR_AXIS"):
+                    if layout == "batched" and ds.ndim >= 1 and ds.shape[0] == batch_size:
+                        sample = f[name][:10]
+                    else:
+                        sample = f[name][:]
+                    data = np.asarray(sample)
+                    ds.stats = {
+                        "shape_per_entity": list(data.shape[1:]) if layout == "batched" and ds.ndim > 0 else list(data.shape),
+                        "min": _safe_float(np.nanmin(data)) if data.dtype.kind == "f" and data.size > 0 else None,
+                        "max": _safe_float(np.nanmax(data)) if data.dtype.kind == "f" and data.size > 0 else None,
+                    }
+            except Exception as e:
+                ds.stats = {"error": str(e)}
+
+
+def _sample_files(h5_files, n=100):
+    """Sample up to n files evenly from a list."""
+    if len(h5_files) <= n:
+        return h5_files
+    step = len(h5_files) // n
+    return h5_files[::step][:n]
+
+
+def _safe_float(val):
+    """Convert numpy scalar to Python float, handling inf/nan."""
+    v = float(val)
+    if np.isnan(v):
+        return "NaN"
+    if np.isinf(v):
+        return "-inf" if v < 0 else "inf"
+    return v
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Read HDF5 Attributes
+# ---------------------------------------------------------------------------
+
+def read_attributes(h5_path, datasets, groups):
+    """Read attributes from root, groups, and datasets.
+
+    Returns:
+        (dict, dict, dict): root_attrs, group_attrs, dataset_attrs.
+    """
+    root_attrs = {}
+    group_attrs = {}
+    dataset_attrs = {}
+
+    with h5py.File(h5_path, "r") as f:
+        for k, v in f.attrs.items():
+            root_attrs[k] = _attr_to_python(v)
+
+        for g in groups:
+            if g in f and f[g].attrs:
+                attrs = {k: _attr_to_python(v) for k, v in f[g].attrs.items()}
+                if attrs:
+                    group_attrs[g] = attrs
+
+        for name in datasets:
+            if name in f and f[name].attrs:
+                attrs = {k: _attr_to_python(v) for k, v in f[name].attrs.items()}
+                if attrs:
+                    dataset_attrs[name] = attrs
+
+    return root_attrs, group_attrs, dataset_attrs
+
+
+def _attr_to_python(val):
+    """Convert HDF5 attribute value to a Python-native type."""
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    if isinstance(val, np.generic):
+        return val.item()
+    if isinstance(val, np.ndarray):
+        if val.size <= 10:
+            return val.tolist()
+        return f"array({val.shape}, {val.dtype})"
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Cross-File Consistency Check
+# ---------------------------------------------------------------------------
+
+def check_consistency(h5_files, reference_datasets, layout, batch_size=0, max_files=10):
+    """Compare structure across multiple HDF5 files."""
+    if len(h5_files) <= 1:
+        return []
+
+    issues = []
+    ref_keys = set(reference_datasets.keys())
+    ref_shapes = {n: d.shape for n, d in reference_datasets.items()}
+
+    files_to_check = h5_files[1:]
+    if len(files_to_check) > max_files:
+        step = len(files_to_check) // max_files
+        files_to_check = files_to_check[::step][:max_files]
+
+    for h5_path in files_to_check:
+        try:
+            other = {}
+            with h5py.File(h5_path, "r") as g:
+                def collect(name, obj):
+                    if isinstance(obj, h5py.Dataset):
+                        other[name] = obj.shape
+                g.visititems(collect)
+
+            missing = ref_keys - set(other.keys())
+            extra = set(other.keys()) - ref_keys
+            if missing:
+                issues.append(f"{Path(h5_path).name}: missing datasets {missing}")
+            if extra:
+                issues.append(f"{Path(h5_path).name}: extra datasets {extra}")
+
+            for name in ref_keys & set(other.keys()):
+                if ref_shapes[name] != other[name]:
+                    issues.append(
+                        f"{Path(h5_path).name}: {name} shape {other[name]} != reference {ref_shapes[name]}"
+                    )
+        except Exception as e:
+            issues.append(f"{Path(h5_path).name}: could not open ({e})")
+
+    # For shared axes, verify values are identical
+    shared_names = [n for n, d in reference_datasets.items() if d.category == "SHARED_AXIS"]
+    if shared_names and len(h5_files) > 1:
+        with h5py.File(h5_files[0], "r") as ref_f:
+            ref_data = {n: ref_f[n][:] for n in shared_names}
+
+        check_files = files_to_check[:3]
+        for h5_path in check_files:
+            try:
+                with h5py.File(h5_path, "r") as g:
+                    for name, ref_arr in ref_data.items():
+                        if name in g:
+                            if not np.array_equal(ref_arr, g[name][:]):
+                                issues.append(f"{Path(h5_path).name}: {name} values differ from reference")
+            except Exception:
+                pass
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Step 7: Emit Draft YAML
+# ---------------------------------------------------------------------------
+
+def emit_draft_yaml(result, output_path=None):
+    """Generate a draft YAML config from inspection results.
+
+    Reads the semantic model (catalog_model.yml) to show available
+    options for method, material, etc. in TODO comments.
+
+    Args:
+        result: InspectionResult.
+        output_path: Path to write YAML (None = return as string).
+
+    Returns:
+        str: The YAML content.
+    """
+    model = load_catalog_model()
+
+    lines = []
+
+    def w(line=""):
+        lines.append(line)
+
+    # Header
+    w(f"# AUTO-GENERATED by dcs inspect on {datetime.date.today().isoformat()}")
+    w(f"# Source: {result.source_dir}")
+    w(f"# Files scanned: {len(result.h5_files)} HDF5 ({result.file_pattern})")
+    if result.layout == "batched":
+        w(f"# Entities detected: {result.total_entities:,} ({len(result.h5_files)} files x {result.batch_size:,} batch size)")
+    elif result.layout == "per_entity":
+        w(f"# Entities detected: {result.total_entities:,} (one per file)")
+    w()
+
+    # Identity (TODO)
+    w("# === REQUIRED: Fill in these identity fields ===")
+    w("# Key convention: {METHOD}_{SIM|EXP|BENCH|OPT}_{DISTINGUISHING_FEATURE}")
+    w('key: ""              # TODO: e.g., RIXS_SIM_BROAD_SIGMA')
+    w('label: ""            # TODO: human-readable name (e.g., Broad Sigma)')
+    w()
+
+    # Dataset container metadata (TODO, with options from semantic model)
+    w("# === REQUIRED: Dataset container metadata ===")
+    w("# These fields describe the dataset as a whole and enable")
+    w("# cross-dataset queries like client.search(Key('method') == 'RIXS')")
+    w("metadata:")
+
+    # method (list, required)
+    method_ids = get_allowed_values(model, "methods") if model else []
+    if method_ids:
+        w(f"  method: []           # TODO: select from {method_ids}")
+    else:
+        w("  method: []           # TODO: scientific methods (list)")
+
+    # data_type (required)
+    dt_ids = get_allowed_values(model, "data_types") if model else []
+    if dt_ids:
+        w(f"  data_type: \"\"        # TODO: select from {dt_ids}")
+    else:
+        w('  data_type: ""        # TODO: "simulation" or "experimental"')
+
+    # material (optional)
+    mat_ids = get_allowed_values(model, "materials") if model else []
+    if mat_ids:
+        w(f"  # material: \"\"      # optional, select from {mat_ids}")
+    else:
+        w('  # material: ""      # optional')
+
+    # producer (optional)
+    prod_ids = get_allowed_values(model, "producers") if model else []
+    if prod_ids:
+        w(f"  # producer: \"\"      # optional (simulation code), select from {prod_ids}")
+    else:
+        w('  # producer: ""      # optional (simulation code)')
+
+    # project (optional)
+    proj_ids = get_allowed_values(model, "projects") if model else []
+    if proj_ids:
+        w(f"  # project: \"\"       # optional, select from {proj_ids}")
+    else:
+        w('  # project: ""       # optional')
+
+    w('  # facility: ""      # optional (experimental data)')
+    w('  # description: ""   # optional')
+    w()
+
+    # Data section
+    w("# === Auto-detected ===")
+    w("data:")
+    w(f"  directory: {result.source_dir}")
+    w(f'  file_pattern: "{result.file_pattern}"')
+    w(f"  layout: {result.layout}")
+    if result.layout == "batched":
+        w(f"  # batch_size: {result.batch_size}")
+    w()
+
+    # Parameters
+    params = {n: d for n, d in result.datasets.items() if d.category == "PARAMETER"}
+    if params:
+        w("parameters:")
+        param_groups = set()
+        for name in params:
+            if "/" in name:
+                param_groups.add(name.rsplit("/", 1)[0])
+
+        if param_groups:
+            group = sorted(param_groups)[0]
+            w("  location: group")
+            w(f"  group: /{group}")
+        elif result.layout == "per_entity":
+            w("  location: root_scalars")
+        else:
+            w("  location: root_scalars")
+
+        w(f"  # {len(params)} parameters discovered:")
+        for name, ds in sorted(params.items()):
+            short_name = name.rsplit("/", 1)[-1] if "/" in name else name
+            stat_str = f"  {ds.dtype}"
+            if "min" in ds.stats and ds.stats["min"] is not None:
+                stat_str += f"  range [{ds.stats['min']}, {ds.stats['max']}]"
+            if ds.stats.get("is_constant"):
+                stat_str += "  ** CONSTANT — consider moving to provenance **"
+            w(f"  #   {short_name:<16s}{stat_str}")
+        w()
+
+    # Artifacts
+    artifacts = {n: d for n, d in result.datasets.items() if d.category == "ARTIFACT"}
+    if artifacts:
+        w("# === TODO: Confirm artifact classification ===")
+        if result.layout == "batched":
+            w("# These datasets have shape (batch, ...) with ndim > 1 → classified as artifacts")
+        else:
+            w("# These datasets are multi-dimensional arrays → classified as artifacts")
+        w("artifacts:")
+        for name, ds in sorted(artifacts.items()):
+            short_name = name.rsplit("/", 1)[-1] if "/" in name else name
+            w(f"  - type: {short_name}           # TODO: rename if desired")
+            w(f"    dataset: /{name}")
+            shape_str = ds.stats.get("shape_per_entity", list(ds.shape))
+            nan_str = ""
+            if ds.stats.get("nan_fraction", 0) > 0:
+                nan_str = f", NaN: {ds.stats['nan_fraction']:.1%}"
+            w(f"    # shape per entity: {tuple(shape_str)}, dtype: {ds.dtype}, range: [{ds.stats.get('min', '?')}, {ds.stats.get('max', '?')}]{nan_str}")
+        w()
+
+    # Unclassified (per_entity arrays that need user disambiguation)
+    unclassified = {n: d for n, d in result.datasets.items() if d.category == "ARTIFACT_OR_AXIS"}
+    if unclassified:
+        w("# === TODO: Classify these arrays as artifacts or shared axes ===")
+        w("# Move each entry to either 'artifacts:' or 'shared:' section")
+        w("# Artifacts = output observables (different per entity)")
+        w("# Shared = axes/grids (same across all entities)")
+        w("unclassified:")
+        for name, ds in sorted(unclassified.items()):
+            w(f"  - name: {name}")
+            w(f"    dataset: /{name}")
+            w(f"    # shape: {ds.shape}, dtype: {ds.dtype}")
+            if ds.stats.get("min") is not None:
+                w(f"    # range: [{ds.stats['min']}, {ds.stats['max']}]")
+        w()
+
+    # Shared axes
+    shared = {n: d for n, d in result.datasets.items() if d.category == "SHARED_AXIS"}
+    if shared:
+        w("# === TODO: Confirm shared axes ===")
+        w("# These datasets do NOT have the batch dimension → classified as shared")
+        w("shared:")
+        for name, ds in sorted(shared.items()):
+            short_name = name.rsplit("/", 1)[-1] if "/" in name else name
+            w(f"  - type: {short_name}")
+            w(f"    dataset: /{name}")
+            desc_parts = [f"shape: {tuple(ds.stats.get('shape', ds.shape))}"]
+            if ds.stats.get("monotonic"):
+                desc_parts.append("monotonic")
+            if "range" in ds.stats:
+                desc_parts.append(f"range [{ds.stats['range'][0]}, {ds.stats['range'][1]}]")
+            if "step" in ds.stats:
+                desc_parts.append(f"step={ds.stats['step']:.4g}")
+            w(f"    # {', '.join(desc_parts)}")
+        w()
+
+    # Extra metadata
+    extra = {n: d for n, d in result.datasets.items() if d.category == "EXTRA_METADATA"}
+    if extra:
+        w("# === Additional per-entity data (not under params/) ===")
+        w("# TODO: Keep as metadata, promote to parameter, or remove?")
+        w("extra_metadata:")
+        for name, ds in sorted(extra.items()):
+            w(f"  - dataset: /{name}")
+            shape_str = ds.stats.get("shape_per_entity", list(ds.shape))
+            w(f"    # shape per entity: {tuple(shape_str)}, dtype: {ds.dtype}")
+            if ds.stats.get("min") is not None:
+                w(f"    # range: [{ds.stats['min']}, {ds.stats['max']}]")
+        w()
+
+    # Provenance
+    w()
+    w("# === Provenance (optional) ===")
+    w("# These fields are stored on the dataset container for tracking")
+    w("# how and when data was generated.")
+    w("provenance:")
+    w('  # created_at: ""     # ISO date when data was generated')
+    w('  # code_version: ""   # version of generating code')
+    w('  # code_commit: ""    # git hash of generating code')
+    if result.root_attrs or result.group_attrs:
+        w("  # Discovered from HDF5 attributes:")
+        for k, v in sorted(result.root_attrs.items()):
+            w(f"  # {k}: {v}")
+        for group_name, attrs in sorted(result.group_attrs.items()):
+            w(f"  # {group_name}/ attrs: {attrs}")
+
+    # Recommendations
+    _add_recommendations(result)
+    if result.recommendations:
+        w()
+        w("# === Recommendations for data producer ===")
+        for rec in result.recommendations:
+            w(f"# - {rec}")
+
+    # Consistency verdict
+    w()
+    if result.consistency_issues:
+        w(f"# === Consistency check: FAILED ({len(result.consistency_issues)} issues) ===")
+        for issue in result.consistency_issues:
+            w(f"# ! {issue}")
+    else:
+        n_checked = min(len(result.h5_files), 11)
+        w(f"# === Consistency check: PASSED ({n_checked} files checked) ===")
+
+    yaml_str = "\n".join(lines) + "\n"
+
+    if output_path:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(output_path, "w") as f:
+            f.write(yaml_str)
+        print(f"Draft YAML written to: {output_path}")
+
+    return yaml_str
+
+
+def _add_recommendations(result):
+    """Add recommendations based on what's missing from the data."""
+    recs = result.recommendations
+
+    has_created_at = "created_at" in result.root_attrs or "generated_at" in result.root_attrs
+    has_generator = any(k in result.root_attrs for k in ("generator", "code_version", "software"))
+    has_material = any(k in result.root_attrs for k in ("material", "system", "compound"))
+
+    if not has_created_at:
+        recs.append("No 'created_at' timestamp — add as HDF5 root attribute")
+    if not has_generator:
+        recs.append("No 'generator' or 'code_version' — add as HDF5 root attribute")
+    if not has_material:
+        recs.append("No 'material' identifier — add as HDF5 root attribute")
+
+    for name, ds in result.datasets.items():
+        if ds.category == "PARAMETER" and ds.stats.get("is_constant"):
+            short = name.rsplit("/", 1)[-1] if "/" in name else name
+            recs.append(f"Parameter '{short}' is constant — consider moving to provenance/metadata")
+
+    if result.layout == "per_entity" and len(result.h5_files) > 1:
+        shared = [n for n, d in result.datasets.items() if d.category in ("SHARED_AXIS", "ARTIFACT_OR_AXIS")]
+        if shared:
+            recs.append(f"Shared arrays ({', '.join(shared)}) stored redundantly in every file — consider a single reference file")
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+def inspect_directory(directory):
+    """Run the full 7-step inspection on a data directory.
+
+    Args:
+        directory: Path to the root data directory.
+
+    Returns:
+        InspectionResult with all findings.
+    """
+    directory = str(directory)
+    result = InspectionResult(source_dir=directory, h5_files=[], file_pattern="*.h5", layout="per_entity")
+
+    # Step 1: Find files
+    h5_files, file_pattern = find_h5_files(directory)
+    if not h5_files:
+        print(f"No HDF5 files found in {directory}")
+        return result
+    result.h5_files = [str(f) for f in h5_files]
+    result.file_pattern = file_pattern
+    print(f"Found {len(h5_files)} HDF5 files ({file_pattern})")
+
+    # Step 2: Tree walk (first file)
+    first_file = str(h5_files[0])
+    datasets, groups = walk_h5_tree(first_file)
+    result.datasets = datasets
+    result.groups = groups
+    print(f"  {len(datasets)} datasets, {len(groups)} groups in {h5_files[0].name}")
+
+    # Check for grouped layout (single file with many groups)
+    if len(h5_files) == 1:
+        is_grouped, entity_groups = detect_grouped_layout(first_file)
+        if is_grouped:
+            result.layout = "grouped"
+            result.total_entities = len(entity_groups)
+            print(f"  Layout: grouped ({result.total_entities} entity groups)")
+            with h5py.File(first_file, "r") as f:
+                inner_datasets = {}
+                group_name = entity_groups[0]
+                def visit_inner(name, obj):
+                    if isinstance(obj, h5py.Dataset):
+                        inner_datasets[f"{group_name}/{name}"] = DatasetInfo(
+                            name=f"{group_name}/{name}",
+                            shape=obj.shape, dtype=str(obj.dtype),
+                            ndim=obj.ndim, size=obj.size,
+                        )
+                f[group_name].visititems(visit_inner)
+            for n, d in inner_datasets.items():
+                if n not in datasets:
+                    datasets[n] = d
+            result.datasets = datasets
+            classify_datasets(datasets, groups, "grouped")
+            read_sample_values(first_file, datasets, "grouped")
+            root_attrs, group_attrs, dataset_attrs = read_attributes(first_file, datasets, groups)
+            result.root_attrs = root_attrs
+            result.group_attrs = group_attrs
+            result.dataset_attrs = dataset_attrs
+            return result
+
+    # Step 3: Detect layout and classify
+    layout, batch_size = detect_layout(datasets, h5_files)
+    result.layout = layout
+    result.batch_size = batch_size
+
+    if layout == "batched":
+        result.total_entities = batch_size * len(h5_files)
+        print(f"  Layout: batched (axis-0 = {batch_size}, total = {result.total_entities:,})")
+    else:
+        result.total_entities = len(h5_files)
+        print(f"  Layout: per_entity ({result.total_entities:,} files)")
+
+    classify_datasets(datasets, groups, layout, batch_size)
+
+    cats = Counter(d.category for d in datasets.values())
+    print(f"  Classification: {dict(cats)}")
+
+    # Step 4: Sample values
+    read_sample_values(first_file, datasets, layout, batch_size, all_h5_files=h5_files)
+
+    # Step 5: Attributes
+    root_attrs, group_attrs, dataset_attrs = read_attributes(first_file, datasets, groups)
+    result.root_attrs = root_attrs
+    result.group_attrs = group_attrs
+    result.dataset_attrs = dataset_attrs
+    if root_attrs:
+        print(f"  Root attrs: {root_attrs}")
+
+    # Step 6: Consistency
+    issues = check_consistency(h5_files, datasets, layout, batch_size)
+    result.consistency_issues = issues
+    if issues:
+        print(f"  Consistency: FAILED ({len(issues)} issues)")
+        for issue in issues:
+            print(f"    ! {issue}")
+    else:
+        print(f"  Consistency: PASSED")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Inspect HDF5 data directory and generate a draft YAML contract."
+    )
+    parser.add_argument("directory", help="Path to the data directory")
+    parser.add_argument(
+        "--output", "-o",
+        help="Output path for draft YAML (default: datasets/draft_<dirname>.yml)",
+    )
+    args = parser.parse_args()
+
+    directory = os.path.abspath(args.directory)
+    if not os.path.isdir(directory):
+        print(f"Error: {directory} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    result = inspect_directory(directory)
+
+    if not result.h5_files:
+        sys.exit(1)
+
+    output = args.output
+    if not output:
+        dirname = Path(directory).name.lower().replace(" ", "_").replace("-", "_")
+        output = f"datasets/draft_{dirname}.yml"
+
+    yaml_str = emit_draft_yaml(result, output)
+    print()
+    print(yaml_str)

--- a/tiled_poc/broker/onboarding/schema/__init__.py
+++ b/tiled_poc/broker/onboarding/schema/__init__.py
@@ -1,0 +1,282 @@
+"""YAML contract schema validation for dataset configs.
+
+Validates dataset YAML configs against both structural requirements
+and the semantic model (schema/catalog_model.yml).
+"""
+
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+VALID_LAYOUTS = {"per_entity", "batched", "grouped"}
+VALID_PARAM_LOCATIONS = {"root_scalars", "root_attributes", "group", "group_scalars", "manifest"}
+
+
+class ValidationError(Exception):
+    """Raised when a dataset YAML fails validation."""
+
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__(
+            f"{len(errors)} validation error(s):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+
+def load_catalog_model(model_path=None):
+    """Load the semantic model YAML.
+
+    Args:
+        model_path: Path to catalog_model.yml.
+            Defaults to catalog_model.yml in the same directory as this module.
+
+    Returns:
+        dict: The parsed catalog model, or None if not found.
+    """
+    if model_path is None:
+        model_path = (
+            Path(__file__).parent / "catalog_model.yml"
+        )
+    if not Path(model_path).exists():
+        return None
+
+    yaml = YAML()
+    with open(model_path) as f:
+        return yaml.load(f)
+
+
+def get_allowed_values(model, field_name):
+    """Extract allowed IDs for a vocabulary field from the catalog model.
+
+    Args:
+        model: Parsed catalog model dict.
+        field_name: Key in the model (e.g., "methods", "materials").
+
+    Returns:
+        list[str]: Allowed ID values, or empty list if not found.
+    """
+    if model is None or field_name not in model:
+        return []
+    return [entry["id"] for entry in model[field_name]]
+
+
+def get_alias_map(model, field_name):
+    """Build a mapping from alias IDs to (canonical_id, implies_dict).
+
+    Scans the vocabulary entries for 'aliases' fields and returns a dict
+    that maps each alias to the canonical ID and any implied field values.
+
+    Args:
+        model: Parsed catalog model dict.
+        field_name: Key in the model (e.g., "methods", "materials").
+
+    Returns:
+        dict: {alias_id: {"canonical": canonical_id, "implies": {...}}}
+    """
+    if model is None or field_name not in model:
+        return {}
+    alias_map = {}
+    for entry in model[field_name]:
+        for alias in entry.get("aliases", []):
+            if isinstance(alias, dict):
+                alias_map[alias["id"]] = {
+                    "canonical": entry["id"],
+                    "implies": alias.get("implies", {}),
+                }
+            else:
+                # Simple string alias (e.g., materials aliases: [NIPS, nips3])
+                alias_map[alias] = {
+                    "canonical": entry["id"],
+                    "implies": {},
+                }
+    return alias_map
+
+
+def resolve_aliases(cfg, model):
+    """Resolve any alias values in metadata to their canonical IDs.
+
+    Modifies cfg["metadata"] in place. Returns a list of resolution
+    messages (informational, not warnings).
+
+    Args:
+        cfg: Parsed dataset config dict.
+        model: Parsed catalog model dict.
+
+    Returns:
+        list[str]: Messages about resolved aliases.
+    """
+    if model is None:
+        return []
+    messages = []
+    metadata = cfg.get("metadata", {})
+
+    # Resolve method aliases
+    method_aliases = get_alias_map(model, "methods")
+    methods = metadata.get("method", [])
+    if isinstance(methods, list):
+        resolved = []
+        for m in methods:
+            if m in method_aliases:
+                info = method_aliases[m]
+                resolved.append(info["canonical"])
+                messages.append(
+                    f"Resolved alias '{m}' → '{info['canonical']}'"
+                )
+                # Apply implied fields (e.g., data_type: simulation)
+                for k, v in info.get("implies", {}).items():
+                    if not metadata.get(k):
+                        metadata[k] = v
+                        messages.append(
+                            f"  implied {k}={v} from alias '{m}'"
+                        )
+            else:
+                resolved.append(m)
+        metadata["method"] = resolved
+
+    # Resolve material aliases
+    mat_aliases = get_alias_map(model, "materials")
+    mat = metadata.get("material")
+    if mat and mat in mat_aliases:
+        info = mat_aliases[mat]
+        metadata["material"] = info["canonical"]
+        messages.append(f"Resolved material alias '{mat}' → '{info['canonical']}'")
+
+    return messages
+
+
+def validate(cfg, model_path=None):
+    """Validate a parsed dataset YAML config.
+
+    Args:
+        cfg: dict loaded from YAML.
+        model_path: Optional path to catalog_model.yml.
+
+    Returns:
+        list of warning strings (non-fatal).
+
+    Raises:
+        ValidationError: if required fields are missing or invalid.
+    """
+    errors = []
+    warnings = []
+    model = load_catalog_model(model_path)
+
+    # --- Resolve aliases before validation ---
+    alias_messages = resolve_aliases(cfg, model)
+    for msg in alias_messages:
+        warnings.append(msg)
+
+    # --- Required identity fields ---
+    if not cfg.get("label"):
+        errors.append("'label' is required (e.g., edrixs_sbi)")
+    if not cfg.get("key"):
+        if not cfg.get("key_prefix"):
+            errors.append("'key' is required (dataset container key in Tiled)")
+
+    # --- Data section ---
+    data = cfg.get("data")
+    if not data:
+        errors.append("'data' section is required")
+    else:
+        if not data.get("directory"):
+            errors.append("'data.directory' is required")
+        elif not os.path.isdir(data["directory"]):
+            errors.append(f"'data.directory' does not exist: {data['directory']}")
+
+        layout = data.get("layout")
+        if not layout:
+            errors.append("'data.layout' is required (per_entity | batched | grouped)")
+        elif layout not in VALID_LAYOUTS:
+            errors.append(f"'data.layout' must be one of {VALID_LAYOUTS}, got '{layout}'")
+
+        if not data.get("file_pattern"):
+            warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
+
+    # --- Artifacts ---
+    artifacts = cfg.get("artifacts", [])
+    if not artifacts:
+        errors.append("'artifacts' list is required (at least one artifact)")
+    else:
+        for i, art in enumerate(artifacts):
+            if not art.get("type"):
+                errors.append(f"artifacts[{i}].type is required")
+            if not art.get("dataset"):
+                errors.append(f"artifacts[{i}].dataset is required")
+
+    # --- Parameters (optional but validated if present) ---
+    params = cfg.get("parameters")
+    if params:
+        loc = params.get("location")
+        if loc and loc not in VALID_PARAM_LOCATIONS:
+            errors.append(
+                f"'parameters.location' must be one of {VALID_PARAM_LOCATIONS}, got '{loc}'"
+            )
+        if loc == "group" and not params.get("group"):
+            errors.append("'parameters.group' is required when location is 'group'")
+        if loc == "manifest" and not params.get("manifest"):
+            errors.append("'parameters.manifest' is required when location is 'manifest'")
+
+    # --- Shared axes (optional, validated if present) ---
+    for i, ax in enumerate(cfg.get("shared", [])):
+        if not ax.get("type"):
+            errors.append(f"shared[{i}].type is required")
+        if not ax.get("dataset"):
+            errors.append(f"shared[{i}].dataset is required")
+
+    # --- Provenance (optional, no special validation) ---
+
+    # --- Dataset container metadata: validate against semantic model ---
+    metadata = cfg.get("metadata", {})
+    if model:
+        _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
+        _validate_vocab(metadata, "data_type", "data_types", model, warnings)
+        _validate_vocab(metadata, "material", "materials", model, warnings)
+        _validate_vocab(metadata, "producer", "producers", model, warnings)
+        _validate_vocab(metadata, "facility", "facilities", model, warnings)
+        _validate_vocab(metadata, "project", "projects", model, warnings)
+
+    # --- Cross-field validation ---
+    dt = metadata.get("data_type")
+    if dt == "experimental" and not metadata.get("facility"):
+        warnings.append("data_type is 'experimental' but no 'facility' specified")
+    if dt == "simulation" and not metadata.get("producer"):
+        warnings.append("data_type is 'simulation' but no 'producer' specified")
+    if dt == "experimental" and metadata.get("producer"):
+        warnings.append(
+            "data_type is 'experimental' but 'producer' is set"
+            " — producer is typically for simulations"
+        )
+    if dt == "simulation" and metadata.get("facility"):
+        warnings.append(
+            "data_type is 'simulation' but 'facility' is set"
+            " — facility is typically for experiments"
+        )
+    if not metadata.get("material"):
+        warnings.append("'material' not specified — recommended for discoverability")
+
+    if errors:
+        raise ValidationError(errors)
+
+    return warnings
+
+
+def _validate_vocab(metadata, field, model_key, model, warnings, is_list=False):
+    """Check a metadata field against the catalog model vocabulary.
+
+    Accepts both canonical IDs and known aliases.
+    """
+    value = metadata.get(field)
+    if value is None:
+        return
+    allowed = get_allowed_values(model, model_key)
+    aliases = get_alias_map(model, model_key)
+    if not allowed:
+        return
+    all_accepted = set(allowed) | set(aliases.keys())
+    values = value if is_list and isinstance(value, list) else [value]
+    for v in values:
+        if v not in all_accepted:
+            warnings.append(
+                f"metadata.{field} '{v}' not in catalog model — allowed: {allowed}"
+            )

--- a/tiled_poc/broker/onboarding/schema/catalog_model.yml
+++ b/tiled_poc/broker/onboarding/schema/catalog_model.yml
@@ -1,0 +1,194 @@
+# Semantic Model: Controlled Vocabulary for Dataset Catalog
+#
+# This file defines the allowed values for dataset metadata fields.
+# The inspector uses it to show options in draft YAMLs.
+# The generator/validator uses it to enforce consistency.
+#
+# To add a new method, material, etc., just add it here.
+
+# --- Methods ---
+# Scientific techniques / observable types that a dataset produces.
+# A dataset may have multiple methods (e.g., multimodal simulation).
+# Aliases map common shorthand names to canonical IDs. When an alias is
+# used, the validator resolves it to the canonical method. Some aliases
+# also imply a default data_type (e.g., EDRIXS → RIXS + simulation).
+methods:
+  - id: INS
+    label: Inelastic Neutron Scattering
+    description: S(Q,E) spectra from neutron scattering (powder or single-crystal)
+  - id: RIXS
+    label: Resonant Inelastic X-ray Scattering
+    description: RIXS spectra (energy loss vs. scattering angle)
+    aliases:
+      - id: EDRIXS
+        implies:
+          data_type: simulation
+  - id: Magnetization
+    label: Magnetization Curves
+    description: M(H) curves along crystal axes or powder-averaged
+  - id: VDP
+    label: Virtual Diffraction Pattern
+    description: Forward-model database spanning multiple observables
+  - id: XPS
+    label: X-ray Photoelectron Spectroscopy
+    description: Core-level photoelectron spectra
+  - id: XES
+    label: X-ray Emission Spectroscopy
+    description: X-ray emission spectra from radiative decay
+  - id: SWT
+    label: Spin Wave Theory
+    description: Linear spin wave theory S(Q,E) calculations
+
+# --- Materials ---
+materials:
+  - id: NiPS3
+    label: "NiPS3"
+    description: Nickel phosphorus trisulfide (van der Waals antiferromagnet)
+    aliases: [NIPS, nips3]
+  - id: NiO
+    label: "NiO"
+    description: Nickel oxide (antiferromagnetic insulator)
+  - id: generic_spin_model
+    label: Generic Spin Model
+    description: Not tied to a specific material
+  - id: YbBi2IO4
+    label: "YbBi2IO4"
+    description: Ytterbium bismuth iodate (2D quantum magnet)
+
+# --- Data Types ---
+data_types:
+  - id: simulation
+    label: Simulation
+  - id: experimental
+    label: Experimental
+  - id: benchmark
+    label: Benchmark
+  - id: optimization
+    label: Optimization
+
+# --- Projects ---
+projects:
+  - id: MAIQMag
+    label: MAIQMag
+    description: Machine-learning AI for Quantum Magnetism
+
+# --- Facilities ---
+# Only relevant for experimental data.
+facilities:
+  - id: LCLS
+    label: LCLS
+    description: Linac Coherent Light Source (SLAC)
+  - id: SNS
+    label: SNS
+    description: Spallation Neutron Source (ORNL)
+  - id: NSLS-II
+    label: NSLS-II
+    description: National Synchrotron Light Source II (BNL)
+
+# --- Producers ---
+# Code repositories that generated the dataset files. Track the repo URL
+# so it's clear exactly what code produced the data. The producer is the
+# pipeline/project, not its dependencies (e.g., edrixs the library is a
+# dependency of lajer2025Hamiltonian, not a separate producer).
+producers:
+  - id: sunny_jl
+    label: Sunny.jl
+    repo: https://github.com/SunnySuite/Sunny.jl
+    description: Julia spin-dynamics simulation (S(Q,E), magnetization)
+  - id: lajer2025Hamiltonian
+    label: lajer2025Hamiltonian
+    repo: https://github.com/mpmdean/lajer2025Hamiltonian
+    description: Bayesian optimization of Hamiltonian parameters from RIXS via edrixs exact-diagonalization
+  - id: edrixs
+    label: EDRIXS
+    repo: https://github.com/NSLS-II/edrixs
+    description: Exact-diagonalization RIXS simulation library (Python)
+
+# --- Dataset metadata fields ---
+# Defines which fields are required/optional on dataset container metadata.
+dataset_fields:
+  required:
+    - name: data_type
+      type: string
+      enum_ref: data_types
+      description: '"simulation" or "experimental"'
+    - name: method
+      type: list
+      enum_ref: methods
+      description: Scientific methods/observables (list)
+  optional:
+    - name: project
+      type: string
+      enum_ref: projects
+      description: Scientific project or collaboration
+    - name: material
+      type: string
+      enum_ref: materials
+      description: Target material or system
+    - name: producer
+      type: string
+      enum_ref: producers
+      description: Code that generated the data (simulation only)
+    - name: producer_version
+      type: string
+      description: Version tag or semver
+    - name: facility
+      type: string
+      enum_ref: facilities
+      description: Where data was collected (experimental only)
+    - name: instrument
+      type: string
+      description: Instrument or beamline
+    - name: organization
+      type: string
+      description: Owning organization or group
+    - name: description
+      type: string
+      description: Human-readable summary
+    - name: created_at
+      type: string
+      description: When the dataset was generated (ISO date)
+    - name: prior_distribution
+      type: string
+      description: How parameters were sampled (e.g., uniform, LHS)
+
+# --- Provenance fields ---
+# Optional fields for tracking how and when data was generated.
+# Stored on the dataset container alongside metadata.
+provenance_fields:
+  - name: created_at
+    type: string
+    description: When the dataset was generated (ISO 8601 date)
+  - name: code_version
+    type: string
+    description: Version tag of the generating code
+  - name: code_commit
+    type: string
+    description: Git commit hash of the generating code
+  - name: generation_host
+    type: string
+    description: Hostname where data was generated
+
+# --- Key convention ---
+# Dataset keys follow the formula: {METHOD}_{DATA_TYPE_SHORT}_{DISTINGUISHING_FEATURE}
+# This makes keys predictable — if you know the method, type, and what's
+# unique about the dataset, you can construct the key without searching.
+#
+# DATA_TYPE_SHORT abbreviations:
+#   simulation   → SIM
+#   experimental → EXP
+#   benchmark    → BENCH
+#   optimization → OPT
+#
+# Examples:
+#   RIXS_SIM_BROAD_SIGMA     — simulated RIXS with broad sigma parameter range
+#   RIXS_EXP_NIPS3_2024      — experimental RIXS on NiPS3 from 2024
+#   INS_SIM_10K              — simulated INS with 10K entities
+#   VDP_SIM_HEISENBERG       — VDP simulation for Heisenberg model
+key_convention:
+  formula: "{METHOD}_{DATA_TYPE_SHORT}_{DISTINGUISHING_FEATURE}"
+  data_type_abbreviations:
+    simulation: SIM
+    experimental: EXP
+    benchmark: BENCH
+    optimization: OPT

--- a/tiled_poc/tests/test_onboarding_generate.py
+++ b/tiled_poc/tests/test_onboarding_generate.py
@@ -1,0 +1,359 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pytest",
+#     "h5py",
+#     "numpy",
+#     "pandas",
+#     "pyarrow",
+#     "ruamel.yaml",
+# ]
+# ///
+"""
+Unit tests for generate module.
+
+Tests cover manifest generation for batched and per-entity layouts,
+root-attribute parameter extraction, shared-axis exclusion, and
+YAML validation errors during loading.
+
+Run with:
+    uv run --with pytest --with h5py --with numpy --with pandas \
+        --with pyarrow --with 'ruamel.yaml' \
+        pytest tests/test_generate.py -v
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+from ruamel.yaml import YAML
+
+# Add project root to path for package imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from broker.onboarding.generate import generate_manifests, load_yaml
+from broker.onboarding.schema import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Helper to write YAML config files
+# ---------------------------------------------------------------------------
+
+def _write_yaml(path, cfg):
+    """Write a dict as YAML to a file path."""
+    yaml = YAML()
+    with open(path, "w") as f:
+        yaml.dump(cfg, f)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def batched_setup(tmp_path):
+    """Create a batched HDF5 file and matching YAML config.
+
+    HDF5 layout:
+        /params/alpha  (3,)
+        /params/beta   (3,)
+        /spectra       (3, 4)
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    fpath = data_dir / "batch.h5"
+    with h5py.File(fpath, "w") as f:
+        g = f.create_group("params")
+        g.create_dataset("alpha", data=np.array([1.0, 2.0, 3.0]))
+        g.create_dataset("beta", data=np.array([0.1, 0.2, 0.3]))
+        f.create_dataset("spectra", data=np.random.randn(3, 4))
+
+    cfg = {
+        "label": "test_batched",
+        "key": "TEST_SIM_BATCHED",
+        "data": {
+            "directory": str(data_dir),
+            "layout": "batched",
+            "file_pattern": "*.h5",
+        },
+        "artifacts": [
+            {"type": "spectra", "dataset": "/spectra"},
+        ],
+        "parameters": {
+            "location": "group",
+            "group": "/params",
+        },
+        "metadata": {
+            "method": ["RIXS"],
+            "data_type": "simulation",
+            "material": "NiPS3",
+            "producer": "edrixs",
+        },
+    }
+
+    yaml_path = tmp_path / "batched.yml"
+    _write_yaml(yaml_path, cfg)
+
+    return yaml_path, data_dir
+
+
+@pytest.fixture
+def per_entity_setup(tmp_path):
+    """Create 3 per-entity HDF5 files and matching YAML config.
+
+    Each file has scalar params at root and a 1D spectrum array.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    for i in range(3):
+        fpath = data_dir / f"entity_{i:03d}.h5"
+        with h5py.File(fpath, "w") as f:
+            f.create_dataset("param_a", data=float(i) * 1.5)
+            f.create_dataset("param_b", data=float(i) * 0.3)
+            f.create_dataset("spectrum", data=np.random.randn(10))
+
+    cfg = {
+        "label": "test_per_entity",
+        "key": "TEST_SIM_PER_ENTITY",
+        "data": {
+            "directory": str(data_dir),
+            "layout": "per_entity",
+            "file_pattern": "*.h5",
+        },
+        "artifacts": [
+            {"type": "spectrum", "dataset": "/spectrum"},
+        ],
+        "parameters": {
+            "location": "root_scalars",
+        },
+        "metadata": {
+            "method": ["RIXS"],
+            "data_type": "simulation",
+            "material": "NiPS3",
+            "producer": "edrixs",
+        },
+    }
+
+    yaml_path = tmp_path / "per_entity.yml"
+    _write_yaml(yaml_path, cfg)
+
+    return yaml_path, data_dir
+
+
+@pytest.fixture
+def root_attributes_setup(tmp_path):
+    """Create a per-entity HDF5 file with root attributes as params.
+
+    Params are stored as file-level HDF5 attributes (f.attrs).
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    for i in range(2):
+        fpath = data_dir / f"sample_{i:03d}.h5"
+        with h5py.File(fpath, "w") as f:
+            f.attrs["temperature"] = 300.0 + i * 10.0
+            f.attrs["pressure"] = 1.0 + i * 0.5
+            f.create_dataset("spectrum", data=np.random.randn(8))
+
+    cfg = {
+        "label": "test_root_attrs",
+        "key": "TEST_SIM_ROOT_ATTRS",
+        "data": {
+            "directory": str(data_dir),
+            "layout": "per_entity",
+            "file_pattern": "*.h5",
+        },
+        "artifacts": [
+            {"type": "spectrum", "dataset": "/spectrum"},
+        ],
+        "parameters": {
+            "location": "root_attributes",
+        },
+        "metadata": {
+            "method": ["RIXS"],
+            "data_type": "simulation",
+            "material": "NiPS3",
+            "producer": "edrixs",
+        },
+    }
+
+    yaml_path = tmp_path / "root_attrs.yml"
+    _write_yaml(yaml_path, cfg)
+
+    return yaml_path, data_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGenerateBatched:
+    """Tests for generate_manifests with batched layout."""
+
+    def test_generate_batched(self, batched_setup):
+        """Create a batched HDF5 + YAML, run generate_manifests, check output."""
+        yaml_path, data_dir = batched_setup
+        output_dir = data_dir.parent / "manifests" / "test_batched"
+
+        ent_path, art_path = generate_manifests(
+            str(yaml_path), output_dir=str(output_dir)
+        )
+
+        assert os.path.exists(ent_path)
+        assert os.path.exists(art_path)
+
+        ent_df = pd.read_parquet(ent_path)
+        art_df = pd.read_parquet(art_path)
+
+        # 3 entities from batch size of 3
+        assert len(ent_df) == 3
+        # 3 entities x 1 artifact type = 3 artifact rows
+        assert len(art_df) == 3
+
+        # Check parameter columns exist
+        assert "alpha" in ent_df.columns
+        assert "beta" in ent_df.columns
+        assert "uid" in ent_df.columns
+        assert "key" in ent_df.columns
+
+        # Check artifact columns
+        assert "uid" in art_df.columns
+        assert "type" in art_df.columns
+        assert "file" in art_df.columns
+        assert "dataset" in art_df.columns
+        assert "index" in art_df.columns
+
+        # All artifact types should be "spectra"
+        assert (art_df["type"] == "spectra").all()
+
+
+class TestGeneratePerEntity:
+    """Tests for generate_manifests with per-entity layout."""
+
+    def test_generate_per_entity(self, per_entity_setup):
+        """Create 3 per-entity HDF5 files + YAML, check output."""
+        yaml_path, data_dir = per_entity_setup
+        output_dir = data_dir.parent / "manifests" / "test_per_entity"
+
+        ent_path, art_path = generate_manifests(
+            str(yaml_path), output_dir=str(output_dir)
+        )
+
+        ent_df = pd.read_parquet(ent_path)
+        art_df = pd.read_parquet(art_path)
+
+        # 3 files = 3 entities
+        assert len(ent_df) == 3
+        # 3 entities x 1 artifact = 3 artifact rows
+        assert len(art_df) == 3
+
+        # Check scalar parameters were extracted
+        assert "param_a" in ent_df.columns
+        assert "param_b" in ent_df.columns
+
+        # Verify parameter values
+        param_a_values = sorted(ent_df["param_a"].tolist())
+        assert param_a_values == pytest.approx([0.0, 1.5, 3.0])
+
+
+class TestGenerateRootAttributes:
+    """Tests for generate_manifests with root_attributes parameter location."""
+
+    def test_generate_root_attributes(self, root_attributes_setup):
+        """Create HDF5 with root attributes as params, verify they appear in entity manifest."""
+        yaml_path, data_dir = root_attributes_setup
+        output_dir = data_dir.parent / "manifests" / "test_root_attrs"
+
+        ent_path, art_path = generate_manifests(
+            str(yaml_path), output_dir=str(output_dir)
+        )
+
+        ent_df = pd.read_parquet(ent_path)
+
+        assert len(ent_df) == 2
+        assert "temperature" in ent_df.columns
+        assert "pressure" in ent_df.columns
+
+        temps = sorted(ent_df["temperature"].tolist())
+        assert temps == pytest.approx([300.0, 310.0])
+
+
+class TestGenerateSharedExcluded:
+    """Tests for shared axes exclusion from entity columns."""
+
+    def test_generate_shared_excluded(self, tmp_path):
+        """Shared axes don't appear as entity columns."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        fpath = data_dir / "batch.h5"
+        with h5py.File(fpath, "w") as f:
+            g = f.create_group("params")
+            g.create_dataset("alpha", data=np.array([1.0, 2.0, 3.0]))
+            f.create_dataset("spectra", data=np.random.randn(3, 4))
+            # Shared axis: energy grid (not batched)
+            f.create_dataset("energy", data=np.linspace(0, 10, 4))
+
+        cfg = {
+            "label": "test_shared",
+            "key": "TEST_SIM_SHARED",
+            "data": {
+                "directory": str(data_dir),
+                "layout": "batched",
+                "file_pattern": "*.h5",
+            },
+            "artifacts": [
+                {"type": "spectra", "dataset": "/spectra"},
+            ],
+            "shared": [
+                {"type": "energy", "dataset": "/energy"},
+            ],
+            "parameters": {
+                "location": "group",
+                "group": "/params",
+            },
+            "metadata": {
+                "method": ["RIXS"],
+                "data_type": "simulation",
+                "material": "NiPS3",
+                "producer": "edrixs",
+            },
+        }
+
+        yaml_path = tmp_path / "shared.yml"
+        _write_yaml(yaml_path, cfg)
+
+        output_dir = tmp_path / "manifests" / "test_shared"
+        ent_path, art_path = generate_manifests(
+            str(yaml_path), output_dir=str(output_dir)
+        )
+
+        ent_df = pd.read_parquet(ent_path)
+
+        # "energy" is a shared axis, not a parameter — it should NOT be in entity columns
+        assert "energy" not in ent_df.columns
+        # But the parameter should be there
+        assert "alpha" in ent_df.columns
+
+
+class TestLoadYaml:
+    """Tests for load_yaml()."""
+
+    def test_load_yaml_validation_error(self, tmp_path):
+        """Invalid YAML (missing key) raises ValidationError."""
+        cfg = {
+            # Missing label, key, data, artifacts
+            "metadata": {"method": ["RIXS"]},
+        }
+        yaml_path = tmp_path / "invalid.yml"
+        _write_yaml(yaml_path, cfg)
+
+        with pytest.raises(ValidationError):
+            load_yaml(str(yaml_path))

--- a/tiled_poc/tests/test_onboarding_inspect.py
+++ b/tiled_poc/tests/test_onboarding_inspect.py
@@ -1,0 +1,221 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pytest",
+#     "h5py",
+#     "numpy",
+#     "ruamel.yaml",
+# ]
+# ///
+"""
+Unit tests for inspect module.
+
+Tests cover HDF5 file discovery, layout detection, directory inspection,
+draft YAML emission, and cross-file consistency checks.
+
+Run with:
+    uv run --with pytest --with h5py --with numpy --with 'ruamel.yaml' \
+        pytest tests/test_inspect.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+# Add project root to path for package imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from broker.onboarding.inspect import (
+    check_consistency,
+    classify_datasets,
+    detect_layout,
+    emit_draft_yaml,
+    find_h5_files,
+    inspect_directory,
+    DatasetInfo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for creating small HDF5 test files
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def per_entity_dir(tmp_path):
+    """Create a directory with 3 per-entity HDF5 files.
+
+    Each file has two scalar parameters and one 1D array.
+    """
+    for i in range(3):
+        fpath = tmp_path / f"entity_{i:03d}.h5"
+        with h5py.File(fpath, "w") as f:
+            f.create_dataset("param_a", data=float(i) * 1.5)
+            f.create_dataset("param_b", data=float(i) * 0.3)
+            f.create_dataset("spectrum", data=np.random.randn(10))
+    return tmp_path
+
+
+@pytest.fixture
+def batched_dir(tmp_path):
+    """Create a directory with a single batched HDF5 file.
+
+    Contains a params group with 1D arrays (batch dim = 3) and
+    a 2D artifact array (3, 4).
+    """
+    fpath = tmp_path / "batch.h5"
+    with h5py.File(fpath, "w") as f:
+        g = f.create_group("params")
+        g.create_dataset("alpha", data=np.array([1.0, 2.0, 3.0]))
+        g.create_dataset("beta", data=np.array([0.1, 0.2, 0.3]))
+        f.create_dataset("spectra", data=np.random.randn(3, 4))
+        # A scalar that is not part of the batch dimension
+        f.create_dataset("version", data=1)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestFindH5Files:
+    """Tests for find_h5_files()."""
+
+    def test_find_h5_files(self, per_entity_dir):
+        """Creates tmp dir with 3 .h5 files, verifies find_h5_files returns them."""
+        files, pattern = find_h5_files(per_entity_dir)
+        assert len(files) == 3
+        assert all(str(f).endswith(".h5") for f in files)
+        assert isinstance(pattern, str)
+
+    def test_find_h5_files_empty(self, tmp_path):
+        """Returns empty list for a directory with no HDF5 files."""
+        files, pattern = find_h5_files(tmp_path)
+        assert files == []
+
+
+class TestDetectLayout:
+    """Tests for detect_layout()."""
+
+    def test_detect_layout_batched(self, batched_dir):
+        """Single file with arrays sharing axis-0 size > 1, plus scalar -> batched."""
+        fpath = batched_dir / "batch.h5"
+        datasets = {}
+        with h5py.File(fpath, "r") as f:
+            def visit(name, obj):
+                if isinstance(obj, h5py.Dataset):
+                    datasets[name] = DatasetInfo(
+                        name=name,
+                        shape=obj.shape,
+                        dtype=str(obj.dtype),
+                        ndim=obj.ndim,
+                        size=obj.size,
+                    )
+            f.visititems(visit)
+
+        h5_files = sorted(batched_dir.glob("*.h5"))
+        layout, batch_size = detect_layout(datasets, h5_files)
+        assert layout == "batched"
+        assert batch_size == 3
+
+    def test_detect_layout_per_entity(self, per_entity_dir):
+        """Multiple files with scalar datasets -> per_entity."""
+        fpath = sorted(per_entity_dir.glob("*.h5"))[0]
+        datasets = {}
+        with h5py.File(fpath, "r") as f:
+            def visit(name, obj):
+                if isinstance(obj, h5py.Dataset):
+                    datasets[name] = DatasetInfo(
+                        name=name,
+                        shape=obj.shape,
+                        dtype=str(obj.dtype),
+                        ndim=obj.ndim,
+                        size=obj.size,
+                    )
+            f.visititems(visit)
+
+        h5_files = sorted(per_entity_dir.glob("*.h5"))
+        layout, batch_size = detect_layout(datasets, h5_files)
+        assert layout == "per_entity"
+        assert batch_size == 0
+
+
+class TestInspectDirectory:
+    """Tests for inspect_directory()."""
+
+    def test_inspect_directory_batched(self, batched_dir):
+        """Creates a batched HDF5 file, runs inspect_directory, checks result."""
+        result = inspect_directory(batched_dir)
+        assert result.layout == "batched"
+        assert result.batch_size == 3
+        assert result.total_entities == 3
+        assert len(result.h5_files) == 1
+        # Check that datasets were found
+        assert len(result.datasets) > 0
+        # Check that spectra was classified as ARTIFACT
+        assert any(
+            d.category == "ARTIFACT" for d in result.datasets.values()
+            if "spectra" in d.name
+        )
+
+    def test_inspect_directory_empty(self, tmp_path):
+        """Returns an InspectionResult with no files for an empty directory."""
+        result = inspect_directory(tmp_path)
+        assert result.h5_files == []
+
+
+class TestEmitDraftYaml:
+    """Tests for emit_draft_yaml()."""
+
+    def test_emit_draft_yaml_has_key_convention(self, batched_dir):
+        """emit_draft_yaml output contains 'Key convention'."""
+        result = inspect_directory(batched_dir)
+        yaml_str = emit_draft_yaml(result)
+        assert "Key convention" in yaml_str
+
+    def test_emit_draft_yaml_no_round_in_provenance(self, batched_dir):
+        """Provenance section doesn't mention 'round:' or 'prior_distribution:'."""
+        result = inspect_directory(batched_dir)
+        yaml_str = emit_draft_yaml(result)
+        # The provenance section should not contain these fields
+        # (they belong in dataset_fields, not in the draft provenance block)
+        provenance_start = yaml_str.find("provenance:")
+        if provenance_start >= 0:
+            provenance_section = yaml_str[provenance_start:]
+            # Check that round and prior_distribution are not emitted as
+            # provenance entries (they may appear in comments about
+            # dataset_fields but not as provenance keys)
+            for line in provenance_section.split("\n"):
+                # Only check non-comment content lines under provenance
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#"):
+                    assert "round:" not in stripped
+                    assert "prior_distribution:" not in stripped
+
+
+class TestConsistencyCheck:
+    """Tests for check_consistency()."""
+
+    def test_consistency_check_pass(self, per_entity_dir):
+        """Two identical-structure files produce no consistency issues."""
+        h5_files = sorted(per_entity_dir.glob("*.h5"))
+        assert len(h5_files) >= 2
+
+        # Build reference datasets from the first file
+        ref_datasets = {}
+        with h5py.File(h5_files[0], "r") as f:
+            def visit(name, obj):
+                if isinstance(obj, h5py.Dataset):
+                    ref_datasets[name] = DatasetInfo(
+                        name=name,
+                        shape=obj.shape,
+                        dtype=str(obj.dtype),
+                        ndim=obj.ndim,
+                        size=obj.size,
+                    )
+            f.visititems(visit)
+
+        issues = check_consistency(h5_files, ref_datasets, "per_entity")
+        assert issues == []

--- a/tiled_poc/tests/test_onboarding_schema.py
+++ b/tiled_poc/tests/test_onboarding_schema.py
@@ -1,0 +1,187 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pytest",
+#     "ruamel.yaml",
+# ]
+# ///
+"""
+Unit tests for schema module.
+
+Tests cover loading the catalog model, vocabulary lookups, alias resolution,
+and YAML config validation.
+
+Run with:
+    uv run --with pytest --with 'ruamel.yaml' pytest tests/test_schema.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add project root to path for package imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from broker.onboarding.schema import (
+    ValidationError,
+    get_alias_map,
+    get_allowed_values,
+    load_catalog_model,
+    resolve_aliases,
+    validate,
+)
+
+
+@pytest.fixture
+def minimal_valid_config(tmp_path):
+    """A minimal config dict that passes validation."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return {
+        "label": "test_dataset",
+        "key": "TEST_SIM_BASIC",
+        "data": {
+            "directory": str(data_dir),
+            "layout": "per_entity",
+            "file_pattern": "*.h5",
+        },
+        "artifacts": [
+            {"type": "spectrum", "dataset": "/spectrum"},
+        ],
+        "metadata": {
+            "method": ["RIXS"],
+            "data_type": "simulation",
+            "material": "NiPS3",
+            "producer": "edrixs",
+        },
+    }
+
+
+class TestLoadCatalogModel:
+    """Tests for load_catalog_model()."""
+
+    def test_load_catalog_model(self):
+        """Loading the real catalog_model.yml returns a dict with 'methods' key."""
+        model = load_catalog_model()
+        assert model is not None
+        assert isinstance(model, dict)
+        assert "methods" in model
+
+    def test_load_catalog_model_missing(self):
+        """Returns None for a nonexistent path."""
+        result = load_catalog_model("/nonexistent/path/catalog_model.yml")
+        assert result is None
+
+
+class TestGetAllowedValues:
+    """Tests for get_allowed_values()."""
+
+    def test_get_allowed_values(self):
+        """Pass a minimal model dict, get back list of IDs."""
+        model = {
+            "methods": [
+                {"id": "RIXS", "label": "RIXS"},
+                {"id": "INS", "label": "INS"},
+            ]
+        }
+        result = get_allowed_values(model, "methods")
+        assert result == ["RIXS", "INS"]
+
+    def test_get_allowed_values_missing_field(self):
+        """Returns empty list for a field not in the model."""
+        model = {"methods": [{"id": "RIXS"}]}
+        assert get_allowed_values(model, "materials") == []
+
+    def test_get_allowed_values_none_model(self):
+        """Returns empty list when model is None."""
+        assert get_allowed_values(None, "methods") == []
+
+
+class TestGetAliasMap:
+    """Tests for get_alias_map()."""
+
+    def test_get_alias_map_dict_alias(self):
+        """EDRIXS alias from the real model maps to RIXS with implies."""
+        model = load_catalog_model()
+        alias_map = get_alias_map(model, "methods")
+        assert "EDRIXS" in alias_map
+        assert alias_map["EDRIXS"]["canonical"] == "RIXS"
+        assert alias_map["EDRIXS"]["implies"].get("data_type") == "simulation"
+
+    def test_get_alias_map_string_alias(self):
+        """NiPS3 string aliases resolve."""
+        model = load_catalog_model()
+        alias_map = get_alias_map(model, "materials")
+        assert "NIPS" in alias_map
+        assert alias_map["NIPS"]["canonical"] == "NiPS3"
+        assert alias_map["NIPS"]["implies"] == {}
+        assert "nips3" in alias_map
+        assert alias_map["nips3"]["canonical"] == "NiPS3"
+
+
+class TestResolveAliases:
+    """Tests for resolve_aliases()."""
+
+    def test_resolve_aliases_method(self):
+        """cfg with method=[EDRIXS] resolves to [RIXS] and implies data_type=simulation."""
+        model = load_catalog_model()
+        cfg = {"metadata": {"method": ["EDRIXS"]}}
+        messages = resolve_aliases(cfg, model)
+        assert cfg["metadata"]["method"] == ["RIXS"]
+        assert cfg["metadata"]["data_type"] == "simulation"
+        assert any("EDRIXS" in m and "RIXS" in m for m in messages)
+
+    def test_resolve_aliases_no_change(self):
+        """cfg with method=[RIXS] stays unchanged."""
+        model = load_catalog_model()
+        cfg = {"metadata": {"method": ["RIXS"]}}
+        messages = resolve_aliases(cfg, model)
+        assert cfg["metadata"]["method"] == ["RIXS"]
+        # No alias resolution messages expected for canonical IDs
+        assert not any("Resolved" in m and "method" in m.lower() for m in messages)
+
+
+class TestValidate:
+    """Tests for validate()."""
+
+    def test_validate_valid_config(self, minimal_valid_config):
+        """A complete config passes validation."""
+        warnings = validate(minimal_valid_config)
+        assert isinstance(warnings, list)
+
+    def test_validate_missing_key(self, minimal_valid_config):
+        """Raises ValidationError when 'key' is missing."""
+        del minimal_valid_config["key"]
+        del minimal_valid_config["label"]
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("label" in e.lower() or "key" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_missing_artifacts(self, minimal_valid_config):
+        """Raises ValidationError when artifacts list is empty."""
+        minimal_valid_config["artifacts"] = []
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("artifact" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_bad_layout(self, minimal_valid_config):
+        """Raises ValidationError for an invalid layout value."""
+        minimal_valid_config["data"]["layout"] = "invalid_layout"
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("layout" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_alias_accepted(self, minimal_valid_config):
+        """EDRIXS in method doesn't produce a vocab warning."""
+        minimal_valid_config["metadata"]["method"] = ["EDRIXS"]
+        warnings = validate(minimal_valid_config)
+        # After alias resolution, EDRIXS becomes RIXS; no "not in catalog model" warning
+        assert not any("not in catalog model" in w and "EDRIXS" in w for w in warnings)
+
+    def test_validate_cross_field_simulation_no_producer(self, minimal_valid_config):
+        """Warns when data_type is simulation but no producer is set."""
+        minimal_valid_config["metadata"]["data_type"] = "simulation"
+        del minimal_valid_config["metadata"]["producer"]
+        warnings = validate(minimal_valid_config)
+        assert any("simulation" in w and "producer" in w for w in warnings)


### PR DESCRIPTION
## Summary
- Cherry-pick the onboarding pipeline from #1 (@amandashack) into `broker/onboarding/` subpackage
- **inspect.py**: auto-scan HDF5 directories, detect layout (per_entity/batched/grouped), classify datasets, emit draft YAML with TODO markers
- **generate.py**: generic manifest generator from YAML configs — handles 3 layouts x 5 parameter sources, replaces dataset-specific scripts
- **schema/**: YAML validator with controlled vocabulary (`catalog_model.yml`), alias resolution (e.g. EDRIXS -> RIXS implies data_type=simulation)
- CLI entry points: `inspect_main()` and `generate_main()` added to `broker/cli.py`

Workflow: `inspect /data/` -> draft YAML -> user edits -> `generate config.yml` -> Parquet manifests -> existing `ingest`

**9 files changed, +2,690/-5 lines. 29 new tests, all passing.**

Original work by @amandashack in #1. This PR lands the high-value onboarding features without the directory restructure, adapted to the current `tiled_poc/broker/` layout.

## Test plan
- [x] 29 new onboarding tests pass (schema, inspect, generate)
- [x] 51 existing tests still pass
- [ ] Manual test: `inspect_main()` on real HDF5 data on SDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)