### PR TITLE
feat: add schema validation and controlled vocabulary

### DIFF
--- a/src/tiled_catalog_broker/schema.py
+++ b/src/tiled_catalog_broker/schema.py
@@ -1,0 +1,282 @@
+"""YAML contract schema validation for dataset configs.
+
+Validates dataset YAML configs against both structural requirements
+and the semantic model (schema/catalog_model.yml).
+"""
+
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+VALID_LAYOUTS = {"per_entity", "batched", "grouped"}
+VALID_PARAM_LOCATIONS = {"root_scalars", "root_attributes", "group", "group_scalars", "manifest"}
+
+
+class ValidationError(Exception):
+    """Raised when a dataset YAML fails validation."""
+
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__(
+            f"{len(errors)} validation error(s):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+
+def load_catalog_model(model_path=None):
+    """Load the semantic model YAML.
+
+    Args:
+        model_path: Path to catalog_model.yml.
+            Defaults to schema/catalog_model.yml relative to the package.
+
+    Returns:
+        dict: The parsed catalog model, or None if not found.
+    """
+    if model_path is None:
+        model_path = (
+            Path(__file__).parent / "schema" / "catalog_model.yml"
+        )
+    if not Path(model_path).exists():
+        return None
+
+    yaml = YAML()
+    with open(model_path) as f:
+        return yaml.load(f)
+
+
+def get_allowed_values(model, field_name):
+    """Extract allowed IDs for a vocabulary field from the catalog model.
+
+    Args:
+        model: Parsed catalog model dict.
+        field_name: Key in the model (e.g., "methods", "materials").
+
+    Returns:
+        list[str]: Allowed ID values, or empty list if not found.
+    """
+    if model is None or field_name not in model:
+        return []
+    return [entry["id"] for entry in model[field_name]]
+
+
+def get_alias_map(model, field_name):
+    """Build a mapping from alias IDs to (canonical_id, implies_dict).
+
+    Scans the vocabulary entries for 'aliases' fields and returns a dict
+    that maps each alias to the canonical ID and any implied field values.
+
+    Args:
+        model: Parsed catalog model dict.
+        field_name: Key in the model (e.g., "methods", "materials").
+
+    Returns:
+        dict: {alias_id: {"canonical": canonical_id, "implies": {...}}}
+    """
+    if model is None or field_name not in model:
+        return {}
+    alias_map = {}
+    for entry in model[field_name]:
+        for alias in entry.get("aliases", []):
+            if isinstance(alias, dict):
+                alias_map[alias["id"]] = {
+                    "canonical": entry["id"],
+                    "implies": alias.get("implies", {}),
+                }
+            else:
+                # Simple string alias (e.g., materials aliases: [NIPS, nips3])
+                alias_map[alias] = {
+                    "canonical": entry["id"],
+                    "implies": {},
+                }
+    return alias_map
+
+
+def resolve_aliases(cfg, model):
+    """Resolve any alias values in metadata to their canonical IDs.
+
+    Modifies cfg["metadata"] in place. Returns a list of resolution
+    messages (informational, not warnings).
+
+    Args:
+        cfg: Parsed dataset config dict.
+        model: Parsed catalog model dict.
+
+    Returns:
+        list[str]: Messages about resolved aliases.
+    """
+    if model is None:
+        return []
+    messages = []
+    metadata = cfg.get("metadata", {})
+
+    # Resolve method aliases
+    method_aliases = get_alias_map(model, "methods")
+    methods = metadata.get("method", [])
+    if isinstance(methods, list):
+        resolved = []
+        for m in methods:
+            if m in method_aliases:
+                info = method_aliases[m]
+                resolved.append(info["canonical"])
+                messages.append(
+                    f"Resolved alias '{m}' → '{info['canonical']}'"
+                )
+                # Apply implied fields (e.g., data_type: simulation)
+                for k, v in info.get("implies", {}).items():
+                    if not metadata.get(k):
+                        metadata[k] = v
+                        messages.append(
+                            f"  implied {k}={v} from alias '{m}'"
+                        )
+            else:
+                resolved.append(m)
+        metadata["method"] = resolved
+
+    # Resolve material aliases
+    mat_aliases = get_alias_map(model, "materials")
+    mat = metadata.get("material")
+    if mat and mat in mat_aliases:
+        info = mat_aliases[mat]
+        metadata["material"] = info["canonical"]
+        messages.append(f"Resolved material alias '{mat}' → '{info['canonical']}'")
+
+    return messages
+
+
+def validate(cfg, model_path=None):
+    """Validate a parsed dataset YAML config.
+
+    Args:
+        cfg: dict loaded from YAML.
+        model_path: Optional path to catalog_model.yml.
+
+    Returns:
+        list of warning strings (non-fatal).
+
+    Raises:
+        ValidationError: if required fields are missing or invalid.
+    """
+    errors = []
+    warnings = []
+    model = load_catalog_model(model_path)
+
+    # --- Resolve aliases before validation ---
+    alias_messages = resolve_aliases(cfg, model)
+    for msg in alias_messages:
+        warnings.append(msg)
+
+    # --- Required identity fields ---
+    if not cfg.get("label"):
+        errors.append("'label' is required (e.g., edrixs_sbi)")
+    if not cfg.get("key"):
+        if not cfg.get("key_prefix"):
+            errors.append("'key' is required (dataset container key in Tiled)")
+
+    # --- Data section ---
+    data = cfg.get("data")
+    if not data:
+        errors.append("'data' section is required")
+    else:
+        if not data.get("directory"):
+            errors.append("'data.directory' is required")
+        elif not os.path.isdir(data["directory"]):
+            errors.append(f"'data.directory' does not exist: {data['directory']}")
+
+        layout = data.get("layout")
+        if not layout:
+            errors.append("'data.layout' is required (per_entity | batched | grouped)")
+        elif layout not in VALID_LAYOUTS:
+            errors.append(f"'data.layout' must be one of {VALID_LAYOUTS}, got '{layout}'")
+
+        if not data.get("file_pattern"):
+            warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
+
+    # --- Artifacts ---
+    artifacts = cfg.get("artifacts", [])
+    if not artifacts:
+        errors.append("'artifacts' list is required (at least one artifact)")
+    else:
+        for i, art in enumerate(artifacts):
+            if not art.get("type"):
+                errors.append(f"artifacts[{i}].type is required")
+            if not art.get("dataset"):
+                errors.append(f"artifacts[{i}].dataset is required")
+
+    # --- Parameters (optional but validated if present) ---
+    params = cfg.get("parameters")
+    if params:
+        loc = params.get("location")
+        if loc and loc not in VALID_PARAM_LOCATIONS:
+            errors.append(
+                f"'parameters.location' must be one of {VALID_PARAM_LOCATIONS}, got '{loc}'"
+            )
+        if loc == "group" and not params.get("group"):
+            errors.append("'parameters.group' is required when location is 'group'")
+        if loc == "manifest" and not params.get("manifest"):
+            errors.append("'parameters.manifest' is required when location is 'manifest'")
+
+    # --- Shared axes (optional, validated if present) ---
+    for i, ax in enumerate(cfg.get("shared", [])):
+        if not ax.get("type"):
+            errors.append(f"shared[{i}].type is required")
+        if not ax.get("dataset"):
+            errors.append(f"shared[{i}].dataset is required")
+
+    # --- Provenance (optional, no special validation) ---
+
+    # --- Dataset container metadata: validate against semantic model ---
+    metadata = cfg.get("metadata", {})
+    if model:
+        _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
+        _validate_vocab(metadata, "data_type", "data_types", model, warnings)
+        _validate_vocab(metadata, "material", "materials", model, warnings)
+        _validate_vocab(metadata, "producer", "producers", model, warnings)
+        _validate_vocab(metadata, "facility", "facilities", model, warnings)
+        _validate_vocab(metadata, "project", "projects", model, warnings)
+
+    # --- Cross-field validation ---
+    dt = metadata.get("data_type")
+    if dt == "experimental" and not metadata.get("facility"):
+        warnings.append("data_type is 'experimental' but no 'facility' specified")
+    if dt == "simulation" and not metadata.get("producer"):
+        warnings.append("data_type is 'simulation' but no 'producer' specified")
+    if dt == "experimental" and metadata.get("producer"):
+        warnings.append(
+            "data_type is 'experimental' but 'producer' is set"
+            " — producer is typically for simulations"
+        )
+    if dt == "simulation" and metadata.get("facility"):
+        warnings.append(
+            "data_type is 'simulation' but 'facility' is set"
+            " — facility is typically for experiments"
+        )
+    if not metadata.get("material"):
+        warnings.append("'material' not specified — recommended for discoverability")
+
+    if errors:
+        raise ValidationError(errors)
+
+    return warnings
+
+
+def _validate_vocab(metadata, field, model_key, model, warnings, is_list=False):
+    """Check a metadata field against the catalog model vocabulary.
+
+    Accepts both canonical IDs and known aliases.
+    """
+    value = metadata.get(field)
+    if value is None:
+        return
+    allowed = get_allowed_values(model, model_key)
+    aliases = get_alias_map(model, model_key)
+    if not allowed:
+        return
+    all_accepted = set(allowed) | set(aliases.keys())
+    values = value if is_list and isinstance(value, list) else [value]
+    for v in values:
+        if v not in all_accepted:
+            warnings.append(
+                f"metadata.{field} '{v}' not in catalog model — allowed: {allowed}"
+            )

--- a/src/tiled_catalog_broker/schema/catalog_model.yml
+++ b/src/tiled_catalog_broker/schema/catalog_model.yml
@@ -1,0 +1,194 @@
+# Semantic Model: Controlled Vocabulary for Dataset Catalog
+#
+# This file defines the allowed values for dataset metadata fields.
+# The inspector uses it to show options in draft YAMLs.
+# The generator/validator uses it to enforce consistency.
+#
+# To add a new method, material, etc., just add it here.
+
+# --- Methods ---
+# Scientific techniques / observable types that a dataset produces.
+# A dataset may have multiple methods (e.g., multimodal simulation).
+# Aliases map common shorthand names to canonical IDs. When an alias is
+# used, the validator resolves it to the canonical method. Some aliases
+# also imply a default data_type (e.g., EDRIXS → RIXS + simulation).
+methods:
+  - id: INS
+    label: Inelastic Neutron Scattering
+    description: S(Q,E) spectra from neutron scattering (powder or single-crystal)
+  - id: RIXS
+    label: Resonant Inelastic X-ray Scattering
+    description: RIXS spectra (energy loss vs. scattering angle)
+    aliases:
+      - id: EDRIXS
+        implies:
+          data_type: simulation
+  - id: Magnetization
+    label: Magnetization Curves
+    description: M(H) curves along crystal axes or powder-averaged
+  - id: VDP
+    label: Virtual Diffraction Pattern
+    description: Forward-model database spanning multiple observables
+  - id: XPS
+    label: X-ray Photoelectron Spectroscopy
+    description: Core-level photoelectron spectra
+  - id: XES
+    label: X-ray Emission Spectroscopy
+    description: X-ray emission spectra from radiative decay
+  - id: SWT
+    label: Spin Wave Theory
+    description: Linear spin wave theory S(Q,E) calculations
+
+# --- Materials ---
+materials:
+  - id: NiPS3
+    label: "NiPS3"
+    description: Nickel phosphorus trisulfide (van der Waals antiferromagnet)
+    aliases: [NIPS, nips3]
+  - id: NiO
+    label: "NiO"
+    description: Nickel oxide (antiferromagnetic insulator)
+  - id: generic_spin_model
+    label: Generic Spin Model
+    description: Not tied to a specific material
+  - id: YbBi2IO4
+    label: "YbBi2IO4"
+    description: Ytterbium bismuth iodate (2D quantum magnet)
+
+# --- Data Types ---
+data_types:
+  - id: simulation
+    label: Simulation
+  - id: experimental
+    label: Experimental
+  - id: benchmark
+    label: Benchmark
+  - id: optimization
+    label: Optimization
+
+# --- Projects ---
+projects:
+  - id: MAIQMag
+    label: MAIQMag
+    description: Machine-learning AI for Quantum Magnetism
+
+# --- Facilities ---
+# Only relevant for experimental data.
+facilities:
+  - id: LCLS
+    label: LCLS
+    description: Linac Coherent Light Source (SLAC)
+  - id: SNS
+    label: SNS
+    description: Spallation Neutron Source (ORNL)
+  - id: NSLS-II
+    label: NSLS-II
+    description: National Synchrotron Light Source II (BNL)
+
+# --- Producers ---
+# Code repositories that generated the dataset files. Track the repo URL
+# so it's clear exactly what code produced the data. The producer is the
+# pipeline/project, not its dependencies (e.g., edrixs the library is a
+# dependency of lajer2025Hamiltonian, not a separate producer).
+producers:
+  - id: sunny_jl
+    label: Sunny.jl
+    repo: https://github.com/SunnySuite/Sunny.jl
+    description: Julia spin-dynamics simulation (S(Q,E), magnetization)
+  - id: lajer2025Hamiltonian
+    label: lajer2025Hamiltonian
+    repo: https://github.com/mpmdean/lajer2025Hamiltonian
+    description: Bayesian optimization of Hamiltonian parameters from RIXS via edrixs exact-diagonalization
+  - id: edrixs
+    label: EDRIXS
+    repo: https://github.com/NSLS-II/edrixs
+    description: Exact-diagonalization RIXS simulation library (Python)
+
+# --- Dataset metadata fields ---
+# Defines which fields are required/optional on dataset container metadata.
+dataset_fields:
+  required:
+    - name: data_type
+      type: string
+      enum_ref: data_types
+      description: '"simulation" or "experimental"'
+    - name: method
+      type: list
+      enum_ref: methods
+      description: Scientific methods/observables (list)
+  optional:
+    - name: project
+      type: string
+      enum_ref: projects
+      description: Scientific project or collaboration
+    - name: material
+      type: string
+      enum_ref: materials
+      description: Target material or system
+    - name: producer
+      type: string
+      enum_ref: producers
+      description: Code that generated the data (simulation only)
+    - name: producer_version
+      type: string
+      description: Version tag or semver
+    - name: facility
+      type: string
+      enum_ref: facilities
+      description: Where data was collected (experimental only)
+    - name: instrument
+      type: string
+      description: Instrument or beamline
+    - name: organization
+      type: string
+      description: Owning organization or group
+    - name: description
+      type: string
+      description: Human-readable summary
+    - name: created_at
+      type: string
+      description: When the dataset was generated (ISO date)
+    - name: prior_distribution
+      type: string
+      description: How parameters were sampled (e.g., uniform, LHS)
+
+# --- Provenance fields ---
+# Optional fields for tracking how and when data was generated.
+# Stored on the dataset container alongside metadata.
+provenance_fields:
+  - name: created_at
+    type: string
+    description: When the dataset was generated (ISO 8601 date)
+  - name: code_version
+    type: string
+    description: Version tag of the generating code
+  - name: code_commit
+    type: string
+    description: Git commit hash of the generating code
+  - name: generation_host
+    type: string
+    description: Hostname where data was generated
+
+# --- Key convention ---
+# Dataset keys follow the formula: {METHOD}_{DATA_TYPE_SHORT}_{DISTINGUISHING_FEATURE}
+# This makes keys predictable — if you know the method, type, and what's
+# unique about the dataset, you can construct the key without searching.
+#
+# DATA_TYPE_SHORT abbreviations:
+#   simulation   → SIM
+#   experimental → EXP
+#   benchmark    → BENCH
+#   optimization → OPT
+#
+# Examples:
+#   RIXS_SIM_BROAD_SIGMA     — simulated RIXS with broad sigma parameter range
+#   RIXS_EXP_NIPS3_2024      — experimental RIXS on NiPS3 from 2024
+#   INS_SIM_10K              — simulated INS with 10K entities
+#   VDP_SIM_HEISENBERG       — VDP simulation for Heisenberg model
+key_convention:
+  formula: "{METHOD}_{DATA_TYPE_SHORT}_{DISTINGUISHING_FEATURE}"
+  data_type_abbreviations:
+    simulation: SIM
+    experimental: EXP
+    benchmark: BENCH
+    optimization: OPT

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,187 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pytest",
+#     "ruamel.yaml",
+# ]
+# ///
+"""
+Unit tests for schema module.
+
+Tests cover loading the catalog model, vocabulary lookups, alias resolution,
+and YAML config validation.
+
+Run with:
+    uv run --with pytest --with 'ruamel.yaml' pytest tests/test_schema.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add project root to path for package imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tiled_catalog_broker.schema import (
+    ValidationError,
+    get_alias_map,
+    get_allowed_values,
+    load_catalog_model,
+    resolve_aliases,
+    validate,
+)
+
+
+@pytest.fixture
+def minimal_valid_config(tmp_path):
+    """A minimal config dict that passes validation."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return {
+        "label": "test_dataset",
+        "key": "TEST_SIM_BASIC",
+        "data": {
+            "directory": str(data_dir),
+            "layout": "per_entity",
+            "file_pattern": "*.h5",
+        },
+        "artifacts": [
+            {"type": "spectrum", "dataset": "/spectrum"},
+        ],
+        "metadata": {
+            "method": ["RIXS"],
+            "data_type": "simulation",
+            "material": "NiPS3",
+            "producer": "edrixs",
+        },
+    }
+
+
+class TestLoadCatalogModel:
+    """Tests for load_catalog_model()."""
+
+    def test_load_catalog_model(self):
+        """Loading the real catalog_model.yml returns a dict with 'methods' key."""
+        model = load_catalog_model()
+        assert model is not None
+        assert isinstance(model, dict)
+        assert "methods" in model
+
+    def test_load_catalog_model_missing(self):
+        """Returns None for a nonexistent path."""
+        result = load_catalog_model("/nonexistent/path/catalog_model.yml")
+        assert result is None
+
+
+class TestGetAllowedValues:
+    """Tests for get_allowed_values()."""
+
+    def test_get_allowed_values(self):
+        """Pass a minimal model dict, get back list of IDs."""
+        model = {
+            "methods": [
+                {"id": "RIXS", "label": "RIXS"},
+                {"id": "INS", "label": "INS"},
+            ]
+        }
+        result = get_allowed_values(model, "methods")
+        assert result == ["RIXS", "INS"]
+
+    def test_get_allowed_values_missing_field(self):
+        """Returns empty list for a field not in the model."""
+        model = {"methods": [{"id": "RIXS"}]}
+        assert get_allowed_values(model, "materials") == []
+
+    def test_get_allowed_values_none_model(self):
+        """Returns empty list when model is None."""
+        assert get_allowed_values(None, "methods") == []
+
+
+class TestGetAliasMap:
+    """Tests for get_alias_map()."""
+
+    def test_get_alias_map_dict_alias(self):
+        """EDRIXS alias from the real model maps to RIXS with implies."""
+        model = load_catalog_model()
+        alias_map = get_alias_map(model, "methods")
+        assert "EDRIXS" in alias_map
+        assert alias_map["EDRIXS"]["canonical"] == "RIXS"
+        assert alias_map["EDRIXS"]["implies"].get("data_type") == "simulation"
+
+    def test_get_alias_map_string_alias(self):
+        """NiPS3 string aliases resolve."""
+        model = load_catalog_model()
+        alias_map = get_alias_map(model, "materials")
+        assert "NIPS" in alias_map
+        assert alias_map["NIPS"]["canonical"] == "NiPS3"
+        assert alias_map["NIPS"]["implies"] == {}
+        assert "nips3" in alias_map
+        assert alias_map["nips3"]["canonical"] == "NiPS3"
+
+
+class TestResolveAliases:
+    """Tests for resolve_aliases()."""
+
+    def test_resolve_aliases_method(self):
+        """cfg with method=[EDRIXS] resolves to [RIXS] and implies data_type=simulation."""
+        model = load_catalog_model()
+        cfg = {"metadata": {"method": ["EDRIXS"]}}
+        messages = resolve_aliases(cfg, model)
+        assert cfg["metadata"]["method"] == ["RIXS"]
+        assert cfg["metadata"]["data_type"] == "simulation"
+        assert any("EDRIXS" in m and "RIXS" in m for m in messages)
+
+    def test_resolve_aliases_no_change(self):
+        """cfg with method=[RIXS] stays unchanged."""
+        model = load_catalog_model()
+        cfg = {"metadata": {"method": ["RIXS"]}}
+        messages = resolve_aliases(cfg, model)
+        assert cfg["metadata"]["method"] == ["RIXS"]
+        # No alias resolution messages expected for canonical IDs
+        assert not any("Resolved" in m and "method" in m.lower() for m in messages)
+
+
+class TestValidate:
+    """Tests for validate()."""
+
+    def test_validate_valid_config(self, minimal_valid_config):
+        """A complete config passes validation."""
+        warnings = validate(minimal_valid_config)
+        assert isinstance(warnings, list)
+
+    def test_validate_missing_key(self, minimal_valid_config):
+        """Raises ValidationError when 'key' is missing."""
+        del minimal_valid_config["key"]
+        del minimal_valid_config["label"]
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("label" in e.lower() or "key" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_missing_artifacts(self, minimal_valid_config):
+        """Raises ValidationError when artifacts list is empty."""
+        minimal_valid_config["artifacts"] = []
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("artifact" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_bad_layout(self, minimal_valid_config):
+        """Raises ValidationError for an invalid layout value."""
+        minimal_valid_config["data"]["layout"] = "invalid_layout"
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("layout" in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_alias_accepted(self, minimal_valid_config):
+        """EDRIXS in method doesn't produce a vocab warning."""
+        minimal_valid_config["metadata"]["method"] = ["EDRIXS"]
+        warnings = validate(minimal_valid_config)
+        # After alias resolution, EDRIXS becomes RIXS; no "not in catalog model" warning
+        assert not any("not in catalog model" in w and "EDRIXS" in w for w in warnings)
+
+    def test_validate_cross_field_simulation_no_producer(self, minimal_valid_config):
+        """Warns when data_type is simulation but no producer is set."""
+        minimal_valid_config["metadata"]["data_type"] = "simulation"
+        del minimal_valid_config["metadata"]["producer"]
+        warnings = validate(minimal_valid_config)
+        assert any("simulation" in w and "producer" in w for w in warnings)


### PR DESCRIPTION
## Summary

- Add `schema.py` — YAML contract validation with structural checks and semantic model enforcement
- Add `schema/catalog_model.yml` — controlled vocabulary for methods, materials, facilities, producers, data types
- Add `tests/test_schema.py` — 13 tests covering model loading, alias resolution, and validation

### What it does

Validates dataset YAML configs against:
1. **Structural requirements** — required fields (label, key, data section, artifacts), valid layouts, valid parameter locations
2. **Semantic model** — methods, materials, producers, facilities checked against controlled vocabulary
3. **Cross-field rules** — experimental requires facility, simulation requires producer
4. **Alias resolution** — e.g. `EDRIXS` → `RIXS` with implied `data_type: simulation`

### Stacks on
- PR #27 (restructure)

## References
- #24 — Controlled vocabulary discussion

## Test plan
- [ ] `pytest tests/test_schema.py -v` passes