### PR TITLE
fix: lazy HDF5 adapter to eliminate Mode B 2s read floor

### DIFF
--- a/tiled_poc/broker/adapters/lazy_hdf5.py
+++ b/tiled_poc/broker/adapters/lazy_hdf5.py
@@ -1,0 +1,170 @@
+"""
+LazyHDF5ArrayAdapter — project-local replacement for Tiled's HDF5ArrayAdapter.
+
+The stock `tiled.adapters.hdf5.HDF5ArrayAdapter` wraps h5py Datasets in
+`dask.delayed → from_delayed → rechunk`. On every catalog read this forces
+`__array__` → `h5py.read_direct` of the ENTIRE registered dataset before
+the user slice is applied (see debug/MODE_B_ROOT_CAUSE.md §4).
+
+This adapter is a drop-in replacement that honors the `parameters["dataset"]`
+and `parameters["slice"]` kwargs that the broker already stores on each
+data_source, and does direct `h5py.Dataset[base_index][user_slice]` indexing.
+That hits h5py's native per-chunk path and reads only the bytes the client
+asked for.
+
+Dispatched via `adapters_by_mimetype` on the private mimetype
+`application/x-hdf5-broker`, so it coexists with stock `application/x-hdf5`.
+"""
+
+import copy
+from typing import Any, List, Optional, Tuple, Union
+
+import h5py
+import numpy
+from numpy.typing import NDArray
+
+from tiled.adapters.core import Adapter
+from tiled.catalog.orm import Node
+from tiled.ndslice import NDBlock, NDSlice
+from tiled.structures.array import ArrayStructure
+from tiled.structures.core import Spec, StructureFamily
+from tiled.structures.data_source import DataSource
+from tiled.type_aliases import JSON
+from tiled.utils import path_from_uri
+
+
+class LazyHDF5ArrayAdapter(Adapter[ArrayStructure]):
+    """Array adapter for single-slice HDF5 entities.
+
+    `base_index` is the slice index into the leading axis of the underlying
+    HDF5 dataset (or None if the registered entity is the full dataset).
+    The registered array structure therefore has shape equal to
+    `ds.shape[1:]` when `base_index is not None`.
+    """
+
+    structure_family = StructureFamily.array
+
+    def __init__(
+        self,
+        file_path: str,
+        dataset_path: str,
+        base_index: Optional[int],
+        structure: ArrayStructure,
+        *,
+        metadata: Optional[JSON] = None,
+        specs: Optional[List[Spec]] = None,
+    ) -> None:
+        self._file_path = file_path
+        self._dataset_path = dataset_path
+        self._base_index = base_index
+        super().__init__(structure, metadata=metadata, specs=specs)
+
+    @classmethod
+    def from_catalog(
+        cls,
+        data_source: DataSource[ArrayStructure],
+        node: Node,
+        /,
+        dataset: Optional[str] = None,
+        slice: Optional[Union[str, int]] = None,
+        **_ignored: Any,
+    ) -> "LazyHDF5ArrayAdapter":
+        """Build adapter from a catalog row.
+
+        The broker stores `parameters = {"dataset": "<path>", "slice": "<int>"}`
+        on the data source row. Tiled's catalog adapter unpacks those into
+        kwargs when invoking this classmethod.
+        """
+        assets = data_source.assets
+        data_uris = [
+            ast.data_uri for ast in assets if ast.parameter == "data_uris"
+        ] or [assets[0].data_uri]
+        file_path = path_from_uri(data_uris[0])
+
+        if dataset is None:
+            raise ValueError(
+                "LazyHDF5ArrayAdapter requires parameters['dataset'] "
+                "(the HDF5 path of the source dataset)."
+            )
+
+        base_index: Optional[int]
+        if slice is None or slice == "":
+            base_index = None
+        elif isinstance(slice, str):
+            base_index = int(slice)
+        else:
+            base_index = int(slice)
+
+        # Validate on-disk shape/dtype against the registered structure
+        # (matches stock HDF5 adapter behavior; saves debugging time when
+        # catalog goes stale).
+        with h5py.File(file_path, "r", locking=False) as f:
+            ds = f[dataset]
+            full_shape = tuple(ds.shape)
+            ds_dtype = ds.dtype
+
+        expected_shape = (
+            full_shape[1:] if base_index is not None else full_shape
+        )
+        registered_shape = tuple(data_source.structure.shape)
+        if expected_shape != registered_shape:
+            raise ValueError(
+                f"Shape mismatch for {file_path}:{dataset}[{base_index}]: "
+                f"registered={registered_shape}, on_disk={expected_shape}"
+            )
+        registered_dtype = data_source.structure.data_type.to_numpy_dtype()
+        if ds_dtype != registered_dtype:
+            raise ValueError(
+                f"Dtype mismatch for {file_path}:{dataset}: "
+                f"registered={registered_dtype}, on_disk={ds_dtype}"
+            )
+
+        return cls(
+            file_path,
+            dataset,
+            base_index,
+            data_source.structure,
+            metadata=copy.deepcopy(node.metadata_),
+            specs=node.specs,
+        )
+
+    def _open_and_select(self) -> Tuple[h5py.File, h5py.Dataset]:
+        f = h5py.File(self._file_path, "r", locking=False)
+        return f, f[self._dataset_path]
+
+    def read(
+        self,
+        slice: NDSlice = NDSlice(...),
+    ) -> NDArray[Any]:
+        """Read user-specified slice of the registered entity.
+
+        Opens h5py per request (cheap on this Lustre view: ~0.5 ms, see
+        debug/bench_open_cost.py). Avoids cross-thread file-handle sharing.
+        """
+        with h5py.File(self._file_path, "r", locking=False) as f:
+            ds = f[self._dataset_path]
+            if self._base_index is not None:
+                # h5py reads exactly the bytes of the one chunk at base_index.
+                row = ds[self._base_index]
+                arr = row[tuple(slice)] if slice else row
+            else:
+                arr = ds[tuple(slice)] if slice else ds[...]
+            return numpy.asarray(arr)
+
+    def read_block(
+        self,
+        block: NDBlock,
+        slice: NDSlice = NDSlice(...),
+    ) -> NDArray[Any]:
+        """Read a dask-style block of the registered entity."""
+        block_slice = block.slice_from_chunks(self._structure.chunks)
+        with h5py.File(self._file_path, "r", locking=False) as f:
+            ds = f[self._dataset_path]
+            if self._base_index is not None:
+                row = ds[self._base_index]
+                arr = row[tuple(block_slice)]
+            else:
+                arr = ds[tuple(block_slice)]
+            if slice:
+                arr = arr[tuple(slice)]
+            return numpy.asarray(arr)

--- a/tiled_poc/broker/bulk_register.py
+++ b/tiled_poc/broker/bulk_register.py
@@ -220,6 +220,12 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir):
                     "h5_path": h5_full_path,
                     "dataset_path": dataset_path,
                     "parameters": ds_params,
+                    "mimetype": (
+                        to_json_safe(art_row["mimetype"])
+                        if "mimetype" in art_df.columns
+                        and pd.notna(art_row.get("mimetype"))
+                        else "application/x-hdf5"
+                    ),
                 })
 
     print(f"  Prepared {len(ent_nodes)} entities, {len(art_nodes)} artifacts")
@@ -378,7 +384,7 @@ def bulk_register(engine, ent_nodes, art_nodes, art_data_sources,
                 {
                     "node_id": node_id,
                     "structure_id": ds["structure_id"],
-                    "mimetype": "application/x-hdf5",
+                    "mimetype": ds["mimetype"],
                     "parameters": json.dumps(ds["parameters"]),
                     "properties": json.dumps({}),
                     "management": "external",


### PR DESCRIPTION
## Summary

- Add project-local `LazyHDF5ArrayAdapter` (`tiled_poc/broker/adapters/lazy_hdf5.py`, ~160 lines) that honors `parameters["dataset"]` and `parameters["slice"]` and indexes h5py directly, bypassing the `dask.delayed → from_delayed → rechunk` wrap that forces full-dataset materialization in Tiled's stock `HDF5ArrayAdapter`.
- Wire `bulk_register.py` to forward an optional per-row `mimetype` column from the artifact manifest into `data_sources.mimetype`, falling back to `application/x-hdf5` when absent (backward compatible).
- Dispatched via Tiled's `adapters_by_mimetype` config hook under a new private mimetype `application/x-hdf5-broker`. Stock `application/x-hdf5` is untouched; existing datasets keep serving through the stock adapter unchanged.
- **49× speedup** on the benchmark: warm mean 2.030 s (stock) → 0.041 s (lazy), same physical file, same server.

Fixes #33

## Test plan

Validated end-to-end on `sdfiana025` against a fresh 8124 server restart with the new adapter wired in. All tests passed:

- [x] Lazy adapter import succeeds at server startup with `PYTHONPATH=$PROJ_DIR/tiled_poc`.
- [x] `EDRIXS_CHUNKED_LAZY/H_lzy*/rixs` (100 entities pointing at `NiPS3_chunked.h5` with `application/x-hdf5-broker` mimetype) serves slice reads at 41 ms warm mean, 31 ms cold mean.
- [x] Pre-existing datasets (`EDRIXS_CHUNKED`, `EDRIXS_ZARR`, `EDRIXS_H5_PER_ENTITY`, `EDRIXS_ZARR_SINGLE`) continue to serve through their stock adapters without regression (sanity-checked via curl after restart).
- [x] Row counts for the four pre-existing datasets unchanged after ingesting the new test dataset (100/100/100/1 before and after).
- [x] `bulk_register.py` fallback path verified: a manifest without a `mimetype` column routes rows to `application/x-hdf5` (default), preserving the existing ingest behavior.

TODO before merging (not in this PR to keep scope tight):

- [ ] Unit test for `prepare_node_data` covering the `mimetype` column presence/absence branches.
- [ ] Unit test for `LazyHDF5ArrayAdapter.read` covering: (a) `base_index is not None`, (b) `base_index is None`, (c) shape/dtype mismatch raises.
- [ ] Zarr analogue (`LazyZarrArrayAdapter`) for the parallel bug in `ZarrArrayAdapter.read` at `tiled/adapters/zarr.py:110`. Out of scope for this PR per the investigation's explicit user direction to focus on HDF5 first.
- [ ] Document the opt-in mimetype in `docs/` or the broker README with a usage example and a note about `PYTHONPATH`.

## Investigation context

Three sessions of investigation across 8 hypotheses. Canonical writeup lives in the data-broker repo at `debug/MODE_B_ROOT_CAUSE.md` §1–§13 (external; not part of this PR). Key findings:

- The bug is adapter-agnostic: `HDF5ArrayAdapter` hits it via `dask.delayed → __array__`, and `ZarrArrayAdapter` hits it via `self._array[self._stencil()]`. Both materialize the full registered array before applying user slicing.
- The axis that matters is **"registered array much bigger than requested slice,"** not storage format.
- Per-entity registration (one file per slice) sidesteps the bug for both backends but is operationally awkward at 10K–10M entities. The custom adapter is the clean fix.
- Tiled's `adapters_by_mimetype` config hook (`tiled/catalog/adapter.py:208-213`) is documented and already passes `data_source.parameters` as kwargs to `from_catalog` — no upstream changes needed to plug in a custom adapter.

## Rebase/cherry-pick note

There are many open feature PRs on this repo right now (`feat/onboarding-pipeline`, `feat/inspect-module`, `feat/generate-module`, etc.). This PR is small and self-contained (3 files, 177 lines added, 1 removed) and doesn't collide with any of them, but we may want to rebase or cherry-pick depending on merge order. The touched regions in `bulk_register.py` are the `prepare_node_data` output dict and the `bulk_register` INSERT statement — both stable areas not being actively refactored in the open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
