### PR TITLE
fix: read mimetype from manifest in HTTP registration

### DIFF
--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -83,7 +83,12 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
 
     # Create data source
     data_source = DataSource(
-        mimetype="application/x-hdf5",
+        mimetype=(
+            to_json_safe(art_row["mimetype"])
+            if "mimetype" in art_row.index
+            and pd.notna(art_row.get("mimetype"))
+            else "application/x-hdf5"
+        ),
         assets=[asset],
         structure_family=StructureFamily.array,
         structure=structure,


### PR DESCRIPTION
## Summary
- HTTP registration (http_register.py) hardcoded mimetype="application/x-hdf5", ignoring the manifest's mimetype column
- Bulk registration (register.py) already reads this column to dispatch to custom adapters (e.g. LazyHDF5ArrayAdapter via application/x-hdf5-broker)
- Apply the same conditional pattern so both registration paths have parity

## Test plan
- [x] All 51 existing unit tests pass unchanged
- [x] Pattern matches register.py:223-228

Generated with [Claude Code](https://claude.com/claude-code)