### PR TITLE
Hoist inline imports to module top

### DIFF
--- a/src/tiled_catalog_broker/bulk_register.py
+++ b/src/tiled_catalog_broker/bulk_register.py
@@ -10,22 +10,24 @@ Dataset-agnostic: reads all metadata columns dynamically from manifests.
 The manifest is the contract -- no hardcoded parameter names or artifact types.
 """
 
+import datetime
+import hashlib
+import json
 import os
 import time
-import json
-import hashlib
 from pathlib import Path
 
-import pandas as pd
 import canonicaljson
+import pandas as pd
 from sqlalchemy import create_engine, text
+from tiled.catalog import from_uri as catalog_from_uri
 
 from .utils import (
+    ARTIFACT_STANDARD_COLS,
+    get_artifact_info,
     make_artifact_key,
     make_entity_key,
     to_json_safe,
-    get_artifact_info,
-    ARTIFACT_STANDARD_COLS,
 )
 
 
@@ -60,8 +62,6 @@ def init_database(db_path, readable_storage):
         db_path: Path to the SQLite database file.
         readable_storage: List of directories Tiled is allowed to read from.
     """
-    from tiled.catalog import from_uri as catalog_from_uri
-
     # Remove existing database for fresh start
     if os.path.exists(db_path):
         print(f"  Removing existing database: {db_path}")
@@ -228,13 +228,11 @@ def bulk_register(engine, ent_nodes, art_nodes, art_data_sources,
         dataset_key: Key for the dataset container (e.g. "VDP").
         dataset_metadata: Metadata dict for the dataset container.
     """
-    import datetime as _dt
-
     start_time = time.time()
 
     # Add tracking fields to metadata
     tracking = {
-        "_last_registered": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "_last_registered": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "_manifest_entity_count": len(ent_nodes),
     }
 

--- a/src/tiled_catalog_broker/cli.py
+++ b/src/tiled_catalog_broker/cli.py
@@ -9,9 +9,22 @@ Provides five commands:
   - tcb register:       HTTP registration against a running Tiled server
 """
 
-import sys
 import argparse
+import sys
 from pathlib import Path
+
+import pandas as pd
+from ruamel.yaml import YAML
+from sqlalchemy import create_engine
+from tiled.catalog import from_uri as catalog_from_uri
+from tiled.client import from_uri as tiled_client_from_uri
+
+from .bulk_register import bulk_register, prepare_node_data, verify_registration
+from .config import get_api_key, get_tiled_url
+from .http_register import register_dataset_http, verify_registration_http
+from .tools.generate import main as _generate_main
+from .tools.inspect import main as _inspect_main
+from .utils import check_server, get_artifact_info, slugify_key
 
 DB_PATH = Path("catalog.db")
 MANIFESTS_DIR = Path("manifests")
@@ -20,8 +33,6 @@ STORAGE_DIR = Path("storage")
 
 def _load_config(config_path):
     """Load a dataset config YAML file."""
-    from ruamel.yaml import YAML
-
     yaml = YAML()
     with open(config_path) as f:
         return yaml.load(f)
@@ -33,8 +44,6 @@ def _require_key(config, config_path):
     register/ingest are read-only with respect to the YAML; if the key is
     missing, the user runs `tcb stamp-key` to fill it in.
     """
-    from .utils import slugify_key
-
     label = config.get("label")
     if not label:
         print(f"\nERROR: {config_path}: 'label' is required.", file=sys.stderr)
@@ -125,7 +134,6 @@ def inspect_main():
     classifies datasets, checks consistency, and emits a YAML with
     TODO markers for fields requiring human judgment.
     """
-    from tiled_catalog_broker.tools.inspect import main as _inspect_main
     _inspect_main()
 
 
@@ -138,7 +146,6 @@ def generate_yaml_main():
     scans the HDF5 files, and produces entities.parquet + artifacts.parquet
     compatible with `tcb ingest`.
     """
-    from tiled_catalog_broker.tools.generate import main as _generate_main
     _generate_main()
 
 
@@ -212,11 +219,6 @@ def ingest_main():
     parser.add_argument("configs", nargs="+", help="Dataset config YAML files")
     args = parser.parse_args()
 
-    import pandas as pd
-    from sqlalchemy import create_engine
-    from tiled_catalog_broker.bulk_register import prepare_node_data, bulk_register, verify_registration
-    from tiled_catalog_broker.utils import get_artifact_info
-
     print("=" * 50)
     print("Ingest")
     print("=" * 50)
@@ -244,7 +246,6 @@ def ingest_main():
     STORAGE_DIR.mkdir(exist_ok=True)
     uri = f"sqlite:///{DB_PATH}"
     if not DB_PATH.exists():
-        from tiled.catalog import from_uri as catalog_from_uri
         print(f"  Creating new catalog: {DB_PATH}")
         catalog_from_uri(
             uri,
@@ -318,11 +319,6 @@ def register_main():
     )
     args = parser.parse_args()
 
-    import pandas as pd
-    from tiled_catalog_broker.utils import check_server, get_artifact_info
-    from tiled_catalog_broker.http_register import register_dataset_http, verify_registration_http
-    from tiled_catalog_broker.config import get_tiled_url, get_api_key
-
     print("=" * 50)
     print("Register (HTTP)")
     print("=" * 50)
@@ -341,8 +337,7 @@ def register_main():
         sys.exit(1)
     print("Server is running.")
 
-    from tiled.client import from_uri
-    client = from_uri(tiled_url, api_key=api_key)
+    client = tiled_client_from_uri(tiled_url, api_key=api_key)
     print(f"Connected to {tiled_url} ({len(client)} existing containers)")
 
     # Load and register each dataset

--- a/src/tiled_catalog_broker/clients/tiled_cache.py
+++ b/src/tiled_catalog_broker/clients/tiled_cache.py
@@ -36,6 +36,9 @@ import time
 from pathlib import Path
 
 import numpy as np
+from tiled.client import from_uri
+
+from ..config import get_api_key, get_tiled_url
 
 
 # ---------------------------------------------------------------------------
@@ -349,7 +352,6 @@ def main():
     args = _build_parser().parse_args()
 
     # Resolve server config
-    from ..config import get_tiled_url, get_api_key
     tiled_url = args.tiled_url or get_tiled_url()
     api_key = args.api_key or get_api_key()
 
@@ -363,7 +365,6 @@ def main():
             print(f"Cache directory does not exist, nothing to clear: {cache_path}")
 
     # Connect to Tiled
-    from tiled.client import from_uri
     print(f"\nConnecting to {tiled_url} ...")
     client = from_uri(tiled_url, api_key=api_key)
     dataset_client = client[args.dataset]

--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -22,13 +22,16 @@ import time
 
 import numpy as np
 import pandas as pd
+from tiled.structures.array import ArrayStructure
+from tiled.structures.core import StructureFamily
+from tiled.structures.data_source import Asset, DataSource, Management
 
 from .utils import (
+    ARTIFACT_STANDARD_COLS,
+    get_artifact_info,
     make_artifact_key,
     make_entity_key,
     to_json_safe,
-    get_artifact_info,
-    ARTIFACT_STANDARD_COLS,
 )
 
 
@@ -47,10 +50,6 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
     Returns:
         Tuple of (DataSource, data_shape, data_dtype).
     """
-    from tiled.structures.core import StructureFamily
-    from tiled.structures.array import ArrayStructure
-    from tiled.structures.data_source import Asset, DataSource, Management
-
     h5_rel_path = art_row["file"]
     uri_base = server_base_dir if server_base_dir is not None else base_dir
     h5_full_path = os.path.join(uri_base, h5_rel_path)
@@ -126,8 +125,6 @@ def register_dataset_http(client, ent_df, art_df, base_dir, label,
     Returns:
         bool: True if any entities were registered.
     """
-    from tiled.structures.core import StructureFamily
-
     start_time = time.time()
     ent_count = 0
     art_count = 0

--- a/src/tiled_catalog_broker/tools/generate.py
+++ b/src/tiled_catalog_broker/tools/generate.py
@@ -25,12 +25,14 @@ Usage:
     dcs generate datasets/edrixs_sbi.yml --append
 """
 
+import argparse
+import datetime
+import hashlib
+import json
 import os
 import sys
-import hashlib
-import datetime
-from pathlib import Path
 from collections import OrderedDict
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -39,7 +41,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from ruamel.yaml import YAML
 
-from .schema import validate, ValidationError
+from ..utils import slugify_key
+from .schema import ValidationError, validate
 
 
 # Columns in external parameter manifests that are not physics parameters.
@@ -86,8 +89,6 @@ def generate_manifests(yaml_path, output_dir=None, append=False):
     """
     cfg = load_yaml(yaml_path)
     config_hash = compute_config_hash(yaml_path)
-
-    from ..utils import slugify_key
 
     label = cfg["label"]
     # UIDs must be stable whether or not `key` has been stamped into the YAML
@@ -570,7 +571,6 @@ def _make_uid(params_or_str, namespace=""):
     parameters are discoverable in the data (e.g. per-entity layout
     with parameters only in filenames).
     """
-    import json
     if isinstance(params_or_str, dict):
         canonical = {
             k: round(v, 12) if isinstance(v, float) else v
@@ -602,8 +602,6 @@ def _to_python(val):
 # ---------------------------------------------------------------------------
 
 def main():
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Generate Parquet manifests from a dataset YAML contract."
     )

--- a/src/tiled_catalog_broker/tools/inspect.py
+++ b/src/tiled_catalog_broker/tools/inspect.py
@@ -9,17 +9,18 @@ Usage:
     dcs inspect /path/to/data/ [--output datasets/draft.yml]
 """
 
+import argparse
+import datetime
 import os
 import sys
-import datetime
-from pathlib import Path
 from collections import Counter
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import h5py
 import numpy as np
 
-from .schema import load_catalog_model, get_allowed_values
+from .schema import get_allowed_values, load_catalog_model
 
 
 # ---------------------------------------------------------------------------
@@ -799,8 +800,6 @@ def inspect_directory(directory):
 # ---------------------------------------------------------------------------
 
 def main():
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Inspect HDF5 data directory and generate a draft YAML contract."
     )

--- a/src/tiled_catalog_broker/utils.py
+++ b/src/tiled_catalog_broker/utils.py
@@ -6,12 +6,15 @@ Common functions used across registration scripts.
 
 import os
 import re
+import ssl
+import urllib.error
+import urllib.request
 
 import h5py
 import numpy as np
 import pandas as pd
 
-from .config import get_tiled_url, get_api_key
+from .config import get_api_key, get_tiled_url
 
 
 def slugify_key(label):
@@ -83,10 +86,6 @@ def check_server(url=None, api_key=None):
     Returns:
         bool: True if server responds, False otherwise.
     """
-    import ssl
-    import urllib.request
-    import urllib.error
-
     if url is None:
         url = get_tiled_url()
     if api_key is None:


### PR DESCRIPTION
## Summary

Move function-local `import` / `from … import …` statements to the top of each module, grouped per PEP 8 (stdlib, third-party, local). Drops a duplicated `from tiled.structures.core import StructureFamily` that appeared in both functions in `http_register.py`.

No behavior change. 78 unit tests pass.

## Stack

Based on `fix/lazy-adapter-default` — merge that first. Part of the 5-PR stack.

## Test plan
- [ ] Unit tests pass
- [ ] `tcb --help` and each subcommand still imports cleanly
