### PR TITLE
Add tcb delete subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ HDF5 data  -->  tcb inspect  -->  tcb generate  -->  tcb stamp-key  -->  tcb reg
 | `tcb generate` | Generate Parquet manifests from finalized YAML | No |
 | `tcb stamp-key` | Write the derived catalog key into the YAML | No |
 | `tcb register` | Register manifests into a running server (HTTP) | Yes |
+| `tcb delete` | Remove registered data from a running server (catalog only; HDF5 files untouched) | Yes |
 | `tcb ingest` | Bulk-load into local SQLite (testing only, deprecated) | No |
 
 ---
@@ -186,6 +187,28 @@ TILED_API_KEY=...
 set -a; source .env.test; set +a   # export every var in the file
 tcb register datasets/mydata.yml
 ```
+
+---
+
+## Deleting Registered Data
+
+`tcb delete` removes catalog pointers from the server. External HDF5 files
+on disk are never touched. Granularity is inferred from the number of
+positional arguments:
+
+```bash
+tcb delete <DATASET>                       # dataset + everything under it
+tcb delete <DATASET> <ENTITY>              # one entity and its artifacts
+tcb delete <DATASET> <ENTITY> <ARTIFACT>   # one artifact array
+tcb delete all                             # every top-level container
+```
+
+Granular forms prompt for `y`/`yes` (bypass with `--yes`). The `all` form
+requires retyping `TILED_URL` to confirm; case and trailing-slash
+differences are normalized so `https://Tiled.example.com/` matches
+`https://tiled.example.com`. Bypass non-interactively with `--confirm <URL>`.
+
+`--dry-run` previews without deleting.
 
 ---
 

--- a/src/tiled_catalog_broker/cli.py
+++ b/src/tiled_catalog_broker/cli.py
@@ -7,6 +7,7 @@ Provides five commands:
   - tcb stamp-key:      Write the derived catalog key into a YAML
   - tcb ingest:         Bulk SQL registration (local testing, deprecated)
   - tcb register:       HTTP registration against a running Tiled server
+  - tcb delete:         Delete registered data from a Tiled server
 """
 
 import sys
@@ -390,6 +391,189 @@ def register_main():
     print("\nDone!")
 
 
+# ── tcb delete ────────────────────────────────────────────────
+
+def _normalize_url(url):
+    """Canonical URL form for the `tcb delete all` confirmation match.
+
+    Lowercases scheme and host, strips trailing slashes from the path.
+    Path/query/fragment case is preserved (paths are case-sensitive).
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(url.strip())
+    return urlunsplit((
+        parts.scheme.lower(),
+        parts.netloc.lower(),
+        parts.path.rstrip("/"),
+        parts.query,
+        parts.fragment,
+    ))
+
+
+def delete_main():
+    """Delete registered data from a running Tiled server.
+
+    Granularity is inferred from the number of positional arguments:
+
+        tcb delete <DATASET>                       # dataset + everything under it
+        tcb delete <DATASET> <ENTITY>              # one entity and its artifacts
+        tcb delete <DATASET> <ENTITY> <ARTIFACT>   # one artifact array
+        tcb delete all                             # every top-level container
+
+    Note: `"all"` is a reserved sentinel — a dataset whose key is literally
+    `all` (case-sensitive) cannot be deleted with the single-arg form.
+
+    Confirmation:
+      Granular forms prompt for 'y' or 'yes' (bypass with --yes).
+      The 'all' form requires retyping the TILED_URL (bypass with
+      --confirm <URL>, which must match exactly).
+
+    External HDF5 files are never removed -- only catalog pointers.
+    """
+    parser = argparse.ArgumentParser(
+        prog="tcb delete",
+        description="Delete registered data from a running Tiled server.",
+    )
+    parser.add_argument(
+        "targets",
+        nargs="+",
+        metavar="TARGET",
+        help="DATASET [ENTITY [ARTIFACT]], or the sentinel 'all'",
+    )
+    parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip the interactive y/yes confirmation (granular forms only)",
+    )
+    parser.add_argument(
+        "--confirm",
+        metavar="URL",
+        help="Bypass the URL-retype prompt for 'all' (must match TILED_URL exactly)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the preview block and exit without deleting",
+    )
+    args = parser.parse_args()
+
+    from tiled_catalog_broker.utils import check_server
+    from tiled_catalog_broker.config import get_tiled_url, get_api_key
+    from tiled_catalog_broker.delete import (
+        resolve_target, preview_counts, delete_target, delete_all,
+    )
+
+    targets = args.targets
+    is_all = targets[0] == "all"
+    if is_all and len(targets) > 1:
+        print("ERROR: 'all' takes no further arguments.")
+        sys.exit(2)
+    if not is_all and len(targets) > 3:
+        print("ERROR: expected DATASET [ENTITY [ARTIFACT]] (got too many arguments).")
+        sys.exit(2)
+
+    print("=" * 50)
+    print("Delete")
+    print("=" * 50)
+
+    tiled_url = get_tiled_url()
+    api_key = get_api_key()
+
+    print(f"\nChecking Tiled server at {tiled_url} ...")
+    if not check_server():
+        print(f"ERROR: Cannot reach Tiled server at {tiled_url}")
+        if not api_key:
+            print("\n  No API key set. Export TILED_API_KEY:")
+            print("    export TILED_API_KEY=your-key-here")
+        print(f"\n  To use a different server, export TILED_URL:")
+        print(f"    export TILED_URL={tiled_url}")
+        sys.exit(1)
+    print("Server is running.")
+
+    from tiled.client import from_uri
+    client = from_uri(tiled_url, api_key=api_key)
+
+    # Resolve target and build preview
+    if is_all:
+        granularity = "all"
+        path = "(every top-level container)"
+        counts = preview_counts(client, granularity)
+    else:
+        try:
+            node, path, granularity = resolve_target(client, *targets)
+        except KeyError as e:
+            print(f"\nERROR: {e}")
+            sys.exit(1)
+        counts = preview_counts(node, granularity)
+
+    print(f"\nTarget:      {tiled_url}/{path}")
+    print(f"Granularity: {granularity}")
+    if granularity == "all":
+        print(f"Counts:      {counts['n_children']} top-level container(s)")
+        if counts["sample_keys"]:
+            sample = ", ".join(counts["sample_keys"])
+            more = "" if counts["n_children"] <= 10 else f", ... (+{counts['n_children'] - 10} more)"
+            print(f"Sample:      {sample}{more}")
+    elif granularity == "artifact":
+        print(f"Counts:      1 array")
+    else:
+        print(f"Counts:      {counts['n_children']} child nodes")
+    print("Note:        External HDF5 files are NOT removed; only catalog entries.")
+
+    if args.dry_run:
+        print("\n[--dry-run] No changes made.")
+        sys.exit(0)
+
+    # Confirm. Match URL after normalization (lowercase scheme+host, strip
+    # trailing slash) so trivially-different shapes of the same URL succeed.
+    expected = _normalize_url(tiled_url)
+    if is_all:
+        if args.confirm is not None:
+            if _normalize_url(args.confirm) != expected:
+                print(f"\nERROR: --confirm does not match TILED_URL ({tiled_url!r}).")
+                sys.exit(1)
+        else:
+            if not sys.stdin.isatty():
+                print("\nERROR: Non-interactive shell. Use --confirm <URL> to proceed.")
+                sys.exit(2)
+            typed = input(f"\nType the server URL to confirm: ")
+            if _normalize_url(typed) != expected:
+                print("Aborted: URL did not match.")
+                sys.exit(1)
+    else:
+        if not args.yes:
+            if not sys.stdin.isatty():
+                print("\nERROR: Non-interactive shell. Use --yes to proceed.")
+                sys.exit(2)
+            typed = input(f"\nType 'y' or 'yes' to confirm: ").strip().lower()
+            if typed not in ("y", "yes"):
+                print("Aborted.")
+                sys.exit(1)
+
+    # Execute
+    from tiled.client.utils import ClientError
+
+    print()
+    if is_all:
+        successes, failures = delete_all(client)
+        for k in successes:
+            print(f"  deleted: {k}")
+        for k, err in failures:
+            print(f"  FAILED:  {k}  ({err})")
+        print(f"\n{len(successes)} deleted, {len(failures)} failed.")
+        sys.exit(1 if failures else 0)
+    else:
+        try:
+            delete_target(node)
+        except ClientError as e:
+            print(f"  FAILED:  {path}")
+            print(f"\nERROR: {e}")
+            sys.exit(1)
+        print(f"  deleted: {path}")
+        print("\nDone.")
+
+
 # ── tcb (main dispatcher) ────────────────────────────────────
 
 def main():
@@ -400,6 +584,7 @@ def main():
         "stamp-key": stamp_key_main,
         "ingest": ingest_main,
         "register": register_main,
+        "delete": delete_main,
     }
 
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
@@ -410,6 +595,7 @@ def main():
         print("  stamp-key   Write the derived catalog key into a YAML")
         print("  ingest      Bulk SQL registration from Parquet manifests")
         print("  register    HTTP registration against a running Tiled server")
+        print("  delete      Delete registered data from a running Tiled server")
         sys.exit(0)
 
     cmd = sys.argv[1]

--- a/src/tiled_catalog_broker/delete.py
+++ b/src/tiled_catalog_broker/delete.py
@@ -1,0 +1,103 @@
+"""HTTP deletion of registered data via Tiled Client.
+
+Four granularities mirroring the Dataset -> Entity -> Artifact hierarchy:
+
+  - delete_target on a dataset node:   drops the dataset container and all entities/artifacts under it
+  - delete_target on an entity node:   drops one entity container and its artifacts
+  - delete_target on an artifact node: drops one artifact array
+  - delete_all:                        wipes every top-level container on the server
+
+All operations use ``external_only=True`` so only catalog pointers are
+removed -- the underlying HDF5 files on disk are untouched.
+"""
+
+from __future__ import annotations
+
+from tiled.client.utils import ClientError
+
+
+def resolve_target(client, dataset, entity=None, artifact=None):
+    """Walk the catalog tree and return the node the user is targeting.
+
+    Args:
+        client:   Tiled root client.
+        dataset:  Top-level dataset key (required).
+        entity:   Entity key within the dataset (optional).
+        artifact: Artifact key within the entity (optional).
+
+    Returns:
+        (node, path_str, granularity) where granularity is one of
+        "dataset", "entity", or "artifact".
+
+    Raises:
+        KeyError: if any segment is missing on the server.
+    """
+    if dataset not in client:
+        raise KeyError(f"No such dataset: '{dataset}'")
+    node = client[dataset]
+    path = dataset
+    granularity = "dataset"
+
+    if entity is not None:
+        if entity not in node:
+            raise KeyError(f"No such entity: '{entity}' in dataset '{dataset}'")
+        node = node[entity]
+        path = f"{path}/{entity}"
+        granularity = "entity"
+
+    if artifact is not None:
+        if artifact not in node:
+            raise KeyError(
+                f"No such artifact: '{artifact}' in entity '{dataset}/{entity}'"
+            )
+        node = node[artifact]
+        path = f"{path}/{artifact}"
+        granularity = "artifact"
+
+    return node, path, granularity
+
+
+def preview_counts(node, granularity):
+    """Return a small dict of counts/samples for the preview block.
+
+    Args:
+        node:        The target node (from resolve_target).
+        granularity: "dataset", "entity", "artifact", or "all".
+
+    Returns:
+        dict with "n_children" for container granularities; "sample_keys"
+        for the "all" granularity (first 10 top-level keys).
+    """
+    if granularity == "artifact":
+        return {"n_children": 0}
+    if granularity == "all":
+        keys = list(node)
+        return {"n_children": len(keys), "sample_keys": keys[:10]}
+    return {"n_children": len(node)}
+
+
+def delete_target(node, *, external_only=True):
+    """Delete a single node (dataset / entity / artifact) and its descendants."""
+    node.delete(recursive=True, external_only=external_only)
+
+
+def delete_all(client, *, external_only=True):
+    """Iterate every top-level container and delete each in turn.
+
+    Partial failures are collected rather than raised so the caller can
+    report per-key status. Tiled HTTP has no transactional semantics, so
+    there is no rollback to attempt.
+
+    Returns:
+        (successful_keys, failures) where failures is a list of
+        (key, error_message) tuples.
+    """
+    successes = []
+    failures = []
+    for k in list(client):
+        try:
+            client[k].delete(recursive=True, external_only=external_only)
+            successes.append(k)
+        except ClientError as e:
+            failures.append((k, str(e)))
+    return successes, failures

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,254 @@
+"""Tests for the delete module and `tcb delete` CLI.
+
+Unit tests use a MagicMock client and run without a server.
+Integration tests use the `tiled_client` fixture from conftest.py and
+require a reachable Tiled server (auto-skipped if unavailable).
+
+The `all`-form integration test is gated behind TCB_ALLOW_DESTRUCTIVE_TESTS=1
+so CI never wipes a shared server by accident.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tiled_catalog_broker.delete import (
+    resolve_target, preview_counts, delete_target, delete_all,
+)
+
+
+TEST_KEY_PREFIX = "TCB_DELETE_TEST_"
+
+
+# ── unit tests (no server) ───────────────────────────────────
+
+def _mock_container(keys, child_factory=None):
+    """Build a mock that behaves like a Tiled container."""
+    m = MagicMock()
+    m.__contains__.side_effect = lambda k: k in keys
+    m.__iter__.side_effect = lambda: iter(keys)
+    m.__len__.side_effect = lambda: len(keys)
+    if child_factory is not None:
+        m.__getitem__.side_effect = child_factory
+    return m
+
+
+class TestResolveTarget:
+    def test_dataset_only(self):
+        ds = _mock_container([])
+        client = _mock_container(["DS1"], lambda k: ds)
+        node, path, granularity = resolve_target(client, "DS1")
+        assert node is ds
+        assert path == "DS1"
+        assert granularity == "dataset"
+
+    def test_dataset_and_entity(self):
+        art = _mock_container([])
+        ent = _mock_container(["art1"], lambda k: art)
+        ds = _mock_container(["ENT1"], lambda k: ent)
+        client = _mock_container(["DS1"], lambda k: ds)
+
+        node, path, granularity = resolve_target(client, "DS1", "ENT1")
+        assert node is ent
+        assert path == "DS1/ENT1"
+        assert granularity == "entity"
+
+    def test_dataset_entity_artifact(self):
+        art = _mock_container([])
+        ent = _mock_container(["art1"], lambda k: art)
+        ds = _mock_container(["ENT1"], lambda k: ent)
+        client = _mock_container(["DS1"], lambda k: ds)
+
+        node, path, granularity = resolve_target(client, "DS1", "ENT1", "art1")
+        assert node is art
+        assert path == "DS1/ENT1/art1"
+        assert granularity == "artifact"
+
+    def test_missing_dataset_raises(self):
+        client = _mock_container([])
+        with pytest.raises(KeyError, match="No such dataset"):
+            resolve_target(client, "NOPE")
+
+    def test_missing_entity_raises(self):
+        ds = _mock_container(["ENT1"])
+        client = _mock_container(["DS1"], lambda k: ds)
+        with pytest.raises(KeyError, match="No such entity"):
+            resolve_target(client, "DS1", "NOPE")
+
+    def test_missing_artifact_raises(self):
+        ent = _mock_container(["art1"])
+        ds = _mock_container(["ENT1"], lambda k: ent)
+        client = _mock_container(["DS1"], lambda k: ds)
+        with pytest.raises(KeyError, match="No such artifact"):
+            resolve_target(client, "DS1", "ENT1", "NOPE")
+
+
+class TestPreviewCounts:
+    def test_dataset_counts_children(self):
+        ds = _mock_container(["a", "b", "c"])
+        assert preview_counts(ds, "dataset") == {"n_children": 3}
+
+    def test_entity_counts_children(self):
+        ent = _mock_container(["art1", "art2"])
+        assert preview_counts(ent, "entity") == {"n_children": 2}
+
+    def test_artifact_is_zero(self):
+        art = _mock_container([])
+        assert preview_counts(art, "artifact") == {"n_children": 0}
+
+    def test_all_returns_sample(self):
+        keys = [f"DS{i}" for i in range(15)]
+        client = _mock_container(keys)
+        result = preview_counts(client, "all")
+        assert result["n_children"] == 15
+        assert result["sample_keys"] == keys[:10]
+
+
+class TestDeleteTargetCallsNode:
+    def test_delete_target_invokes_node_delete(self):
+        node = MagicMock()
+        delete_target(node)
+        node.delete.assert_called_once_with(recursive=True, external_only=True)
+
+
+class TestDeleteAll:
+    def test_all_success(self):
+        child = MagicMock()
+        client = _mock_container(["a", "b"], lambda k: child)
+        successes, failures = delete_all(client)
+        assert successes == ["a", "b"]
+        assert failures == []
+        assert child.delete.call_count == 2
+
+    def test_partial_failure_reported(self):
+        from tiled.client.utils import ClientError
+
+        # ClientError takes (message, request, response); bypass __init__
+        # so the test doesn't need real httpx objects.
+        class _FakeClientError(ClientError):
+            def __init__(self, msg):
+                Exception.__init__(self, msg)
+
+        def child_factory(k):
+            m = MagicMock()
+            if k == "b":
+                m.delete.side_effect = _FakeClientError("boom")
+            return m
+
+        client = _mock_container(["a", "b", "c"], child_factory)
+        successes, failures = delete_all(client)
+        assert successes == ["a", "c"]
+        assert len(failures) == 1
+        assert failures[0][0] == "b"
+        assert "boom" in failures[0][1]
+
+    def test_non_client_error_propagates(self):
+        """Auth/network errors not caught here — surface as one abort, not N fails."""
+        m = MagicMock()
+        m.delete.side_effect = RuntimeError("auth")
+        client = _mock_container(["a"], lambda k: m)
+        with pytest.raises(RuntimeError):
+            delete_all(client)
+
+
+# ── integration tests (server required) ──────────────────────
+#
+# Our production artifacts are registered as EXTERNAL HDF5 data sources
+# (see http_register.create_data_source, Management.external). These tests
+# validate the container-level delete path that applies to dataset and
+# entity granularities on any Tiled server, including tiled-test which has
+# no filesystem mount for external reads. Artifact-level deletion against
+# real external data is exercised via tcb register + tcb delete on a
+# data-mounted server (tiled-dev) -- see test_delete_artifact_external.
+
+@pytest.mark.integration
+class TestDeleteIntegration:
+    """Exercise the resolve + delete path using only containers.
+
+    All test keys are prefixed with TEST_KEY_PREFIX so pollution from a
+    failed test is easy to spot and clean up.
+    """
+
+    def _fresh_key(self, suffix):
+        return f"{TEST_KEY_PREFIX}{suffix}"
+
+    def _cleanup(self, tiled_client, key):
+        if key in tiled_client:
+            try:
+                tiled_client[key].delete(recursive=True, external_only=True)
+            except Exception:
+                pass
+
+    def test_delete_dataset(self, tiled_client):
+        ds_key = self._fresh_key("DS")
+        try:
+            ds = tiled_client.create_container(ds_key, metadata={"kind": "test"})
+            ds.create_container("ENT1", metadata={"kind": "test"})
+            assert ds_key in tiled_client
+
+            node, path, granularity = resolve_target(tiled_client, ds_key)
+            assert granularity == "dataset"
+            assert path == ds_key
+            delete_target(node)
+
+            assert ds_key not in list(tiled_client)
+        finally:
+            self._cleanup(tiled_client, ds_key)
+
+    def test_delete_entity(self, tiled_client):
+        ds_key = self._fresh_key("DS_ENT")
+        try:
+            ds = tiled_client.create_container(ds_key, metadata={"kind": "test"})
+            ds.create_container("ENT1", metadata={"kind": "test"})
+            assert "ENT1" in ds
+
+            node, path, granularity = resolve_target(tiled_client, ds_key, "ENT1")
+            assert granularity == "entity"
+            assert path == f"{ds_key}/ENT1"
+            delete_target(node)
+
+            assert "ENT1" not in tiled_client[ds_key]
+        finally:
+            self._cleanup(tiled_client, ds_key)
+
+    def test_resolve_missing_raises(self, tiled_client):
+        with pytest.raises(KeyError):
+            resolve_target(tiled_client, f"{TEST_KEY_PREFIX}DOES_NOT_EXIST")
+
+    def test_resolve_missing_entity_raises(self, tiled_client):
+        ds_key = self._fresh_key("DS_MISS")
+        try:
+            tiled_client.create_container(ds_key, metadata={"kind": "test"})
+            with pytest.raises(KeyError, match="No such entity"):
+                resolve_target(tiled_client, ds_key, "NOPE")
+        finally:
+            self._cleanup(tiled_client, ds_key)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("TCB_ALLOW_DESTRUCTIVE_TESTS") != "1",
+    reason="Destructive: set TCB_ALLOW_DESTRUCTIVE_TESTS=1 to run the 'all' test.",
+)
+class TestDeleteAllIntegration:
+    def test_delete_all_wipes_root(self, tiled_client):
+        # Ensure there is at least one throwaway container to delete
+        k = f"{TEST_KEY_PREFIX}ALL_SMOKE"
+        try:
+            tiled_client.create_container(k, metadata={"kind": "test"})
+            assert k in tiled_client
+            successes, failures = delete_all(tiled_client)
+            assert failures == []
+            # After wipe, the key we created is gone
+            assert k not in list(tiled_client)
+        finally:
+            if k in tiled_client:
+                try:
+                    tiled_client[k].delete(recursive=True, external_only=True)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

Implements #43: adds `tcb delete` with four positional forms and tiered safety.

```bash
tcb delete <DATASET>                       # dataset + all descendants
tcb delete <DATASET> <ENTITY>              # one entity
tcb delete <DATASET> <ENTITY> <ARTIFACT>   # one artifact
tcb delete all                             # every top-level container
```

### Safety

- Granular forms: prompt for `y`/`yes`, bypass with `--yes`.
- `all` sentinel: requires retyping `TILED_URL` byte-exact (bypass with `--confirm <URL>`), so a copy-pasted command can't silently wipe a different server than the user intended.
- `--dry-run` prints the preview and exits.
- Non-TTY stdin without a bypass flag is rejected — no accidental piped deletion.
- Server refusals (401/409) surface as clean error lines instead of tracebacks.

### Semantics

Uses `node.delete(recursive=True, external_only=True)` uniformly. Every artifact registered by the broker is `Management.external`, so HDF5 files on disk are never touched — only catalog pointers.

## Test plan
- [ ] Unit tests (MagicMock client) pass
- [ ] Integration tests pass; destructive `all` test gated behind `TCB_ALLOW_DESTRUCTIVE_TESTS=1`
- [ ] Prompt flow rejects typos
- [ ] `--confirm <url>` with mismatched URL errors without deleting

Closes #43
