### PR TITLE
[#52] add redis event workers

### DIFF
--- a/amsc-connector/.env.example
+++ b/amsc-connector/.env.example
@@ -1,6 +1,8 @@
 TILED_SINGLE_USER_API_KEY=changeme
 POSTGRES_PASSWORD=changeme
 REDIS_PASSWORD=changeme
+REDIS_HOST=redis
+REDIS_PORT=6379
 TILED_WEBHOOKS_SECRET_KEYS=["your-fernet-key-here"]
 # Allow HTTP and private addresses for webhook delivery (local dev only, never production)
 TILED_WEBHOOKS_ALLOW_HTTP=true

--- a/amsc-connector/compose.yml
+++ b/amsc-connector/compose.yml
@@ -15,6 +15,21 @@ services:
     networks:
       - backend
 
+  amsc-connector-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: samwelborn/tiled-amsc-connector:latest
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      - PYTHONPATH=/app/src
+    volumes:
+      - ./src:/app/src
+    command: ["faststream", "run", "amsc_connector.worker:app", "--reload"]
+    networks:
+      - backend
+
 networks:
   # Existing tiled Docker network; tiled has TILED_WEBHOOKS_ALLOW_HTTP=true and
   # TILED_WEBHOOKS_ALLOW_PRIVATE_ADDRESSES=true so it can deliver webhook POSTs

--- a/amsc-connector/pyproject.toml
+++ b/amsc-connector/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.136.1",
+    "faststream[cli,redis]>=0.6.7",
     "httpx>=0.28.1",
     "pydantic>=2.13.3",
     "pydantic-settings>=2.11.0",

--- a/amsc-connector/src/amsc_connector/api/deps.py
+++ b/amsc-connector/src/amsc_connector/api/deps.py
@@ -3,25 +3,30 @@ import hmac
 from typing import Annotated
 
 from fastapi import Depends, Header, HTTPException, Request
-from pydantic import TypeAdapter
-from tiled.server.schemas import WebhookEvent
+from faststream.redis import RedisBroker
 
+from amsc_connector.core.broker import get_stream_router
 from amsc_connector.core.config import Settings, get_settings
 
-_event_adapter: TypeAdapter[WebhookEvent] = TypeAdapter(WebhookEvent)
+
+def _get_broker() -> RedisBroker:
+    return get_stream_router().broker
 
 
-def verify_signature(body: bytes, secret: str, signature: str) -> bool:
+BrokerDep = Annotated[RedisBroker, Depends(_get_broker)]
+
+
+def _verify_signature(body: bytes, secret: str, signature: str) -> bool:
     expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)
 
 
-async def check_signature(
+async def _check_signature(
     request: Request,
     x_tiled_signature: Annotated[str | None, Header()] = None,
     settings: Settings = Depends(get_settings),
-) -> bytes:
-    """Dependency: validate HMAC signature and return the raw request body."""
+) -> None:
+    """Dependency: validate HMAC signature on the raw request body."""
     body = await request.body()
 
     if settings.webhook_secret is not None:
@@ -29,7 +34,8 @@ async def check_signature(
             raise HTTPException(
                 status_code=401, detail="Missing X-Tiled-Signature header"
             )
-        if not verify_signature(body, settings.webhook_secret, x_tiled_signature):
+        if not _verify_signature(body, settings.webhook_secret, x_tiled_signature):
             raise HTTPException(status_code=401, detail="Invalid signature")
 
-    return body
+
+CheckSignature = Depends(_check_signature)

--- a/amsc-connector/src/amsc_connector/api/deps.py
+++ b/amsc-connector/src/amsc_connector/api/deps.py
@@ -29,13 +29,12 @@ async def _check_signature(
     """Dependency: validate HMAC signature on the raw request body."""
     body = await request.body()
 
-    if settings.webhook_secret is not None:
-        if x_tiled_signature is None:
-            raise HTTPException(
-                status_code=401, detail="Missing X-Tiled-Signature header"
-            )
-        if not _verify_signature(body, settings.webhook_secret, x_tiled_signature):
-            raise HTTPException(status_code=401, detail="Invalid signature")
+    if x_tiled_signature is None:
+        raise HTTPException(
+            status_code=401, detail="Missing X-Tiled-Signature header"
+        )
+    if not _verify_signature(body, settings.webhook_secret, x_tiled_signature):
+        raise HTTPException(status_code=401, detail="Invalid signature")
 
 
 CheckSignature = Depends(_check_signature)

--- a/amsc-connector/src/amsc_connector/api/routes/webhook.py
+++ b/amsc-connector/src/amsc_connector/api/routes/webhook.py
@@ -1,23 +1,38 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header
-from amsc_connector.api.deps import _event_adapter, check_signature
+from fastapi import APIRouter, Header
+from pydantic import BaseModel
+from tiled.server.schemas import WebhookEvent
+
+from amsc_connector.api.deps import BrokerDep, CheckSignature
+from amsc_connector.core.constants import (
+    EVENT_TYPE_TO_STREAM,
+    HEADER_EVENT_ID,
+    STREAM_DLQ,
+)
 
 logger = logging.getLogger(__name__)
-
 router = APIRouter()
 
 
-@router.post("/webhook/event")
+class WebhookResponse(BaseModel):
+    status: str = "ok"
+
+
+# dumb pipe
+@router.post("/webhook/event", dependencies=[CheckSignature])
 async def receive_webhook_event(
-    x_tiled_event_id: Annotated[str | None, Header()] = None,
-    body: Annotated[bytes, Depends(check_signature)] = b"",
-) -> dict:
-    """Receive and validate a webhook event posted by tiled."""
-    event = _event_adapter.validate_json(body)
-
-    logger.info(f"Received webhook event_id={x_tiled_event_id} event={event}")
-
-    # TODO: implement event handling
-    return {"status": "ok"}
+    event: WebhookEvent,
+    broker: BrokerDep,
+    x_tiled_event_id: Annotated[str, Header()],
+) -> WebhookResponse:
+    """Receive a webhook event from tiled and publish it to a Redis stream."""
+    stream = EVENT_TYPE_TO_STREAM.get(event.type)
+    if stream is None:
+        logger.warning("unknown event.type=%s; routing to DLQ", event.type)
+        stream = STREAM_DLQ
+    await broker.publish(
+        event, stream=stream, headers={HEADER_EVENT_ID: x_tiled_event_id}
+    )
+    return WebhookResponse()

--- a/amsc-connector/src/amsc_connector/core/broker.py
+++ b/amsc-connector/src/amsc_connector/core/broker.py
@@ -1,0 +1,10 @@
+from functools import lru_cache
+
+from faststream.redis.fastapi import RedisRouter
+
+from amsc_connector.core.config import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_stream_router() -> RedisRouter:
+    return RedisRouter(get_settings().redis_dsn)

--- a/amsc-connector/src/amsc_connector/core/config.py
+++ b/amsc-connector/src/amsc_connector/core/config.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from pydantic import AliasChoices, AnyHttpUrl, Field
+from pydantic import AliasChoices, AnyHttpUrl, Field, RedisDsn, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -28,6 +28,18 @@ class Settings(BaseSettings):
 
     # Tiled node path to watch; empty string means the catalog root
     webhook_target_path: str = ""
+
+    # Redis connection parameters
+    redis_host: str = "redis"
+    redis_port: int = 6379
+    redis_password: str
+
+    @computed_field
+    @property
+    def redis_dsn(self) -> str:
+        return RedisDsn(
+            f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}"
+        ).unicode_string()
 
 
 @lru_cache(maxsize=1)

--- a/amsc-connector/src/amsc_connector/core/constants.py
+++ b/amsc-connector/src/amsc_connector/core/constants.py
@@ -1,0 +1,11 @@
+from tiled.server.schemas import EventType
+
+STREAM_PREFIX = "amsc:events"
+STREAM_DLQ = f"{STREAM_PREFIX}:dlq"
+SEEN_KEY_PREFIX = "amsc:seen"
+SEEN_TTL_SECONDS = 3600
+HEADER_EVENT_ID = "x-tiled-event-id"
+
+EVENT_TYPE_TO_STREAM: dict[EventType, str] = {
+    e: f"{STREAM_PREFIX}:{e.value}" for e in EventType
+}

--- a/amsc-connector/src/amsc_connector/main.py
+++ b/amsc-connector/src/amsc_connector/main.py
@@ -7,7 +7,10 @@ from fastapi import FastAPI
 from tiled.server.schemas import WebhookRegistrationRequest, WebhookResponse
 
 from amsc_connector.api import api_router
+from amsc_connector.core.broker import get_stream_router
 from amsc_connector.core.config import Settings, get_settings
+
+stream_router = get_stream_router()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -81,3 +84,4 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(title="amsc-connector", lifespan=lifespan)
 app.include_router(api_router)
+app.include_router(stream_router)

--- a/amsc-connector/src/amsc_connector/worker.py
+++ b/amsc-connector/src/amsc_connector/worker.py
@@ -1,0 +1,65 @@
+"""FastStream worker that consumes tiled webhook events from Redis Streams."""
+
+import logging
+import os
+import uuid
+
+from faststream import Header, FastStream, Logger
+from faststream.redis import RedisBroker, StreamSub
+from tiled.server.schemas import (
+    ContainerChildCreatedEvent,
+    ContainerChildMetadataUpdatedEvent,
+    EventType,
+    StreamClosedEvent,
+)
+
+from amsc_connector.core.config import get_settings
+from amsc_connector.core.constants import EVENT_TYPE_TO_STREAM, HEADER_EVENT_ID
+
+logging.basicConfig(level=logging.INFO)
+
+CONSUMER_GROUP = "amsc-connector"
+CONSUMER_NAME = os.getenv("WORKER_ID", f"worker-{uuid.uuid4().hex[:8]}")
+EventIdDep = Header(HEADER_EVENT_ID)
+
+broker = RedisBroker(get_settings().redis_dsn)
+app = FastStream(broker)
+
+
+@broker.subscriber(
+    stream=StreamSub(
+        EVENT_TYPE_TO_STREAM[EventType.container_child_created],
+        group=CONSUMER_GROUP,
+        consumer=CONSUMER_NAME,
+    ),
+)
+async def on_child_created(
+    msg: ContainerChildCreatedEvent, logger: Logger, event_id: str = EventIdDep
+) -> None:
+    logger.info("Received child_created event id=%s: %s", event_id, msg)
+
+
+@broker.subscriber(
+    stream=StreamSub(
+        EVENT_TYPE_TO_STREAM[EventType.container_child_metadata_updated],
+        group=CONSUMER_GROUP,
+        consumer=CONSUMER_NAME,
+    ),
+)
+async def on_metadata_updated(
+    msg: ContainerChildMetadataUpdatedEvent, logger: Logger, event_id: str = EventIdDep
+) -> None:
+    logger.info("Received metadata_updated event id=%s: %s", event_id, msg)
+
+
+@broker.subscriber(
+    stream=StreamSub(
+        EVENT_TYPE_TO_STREAM[EventType.stream_closed],
+        group=CONSUMER_GROUP,
+        consumer=CONSUMER_NAME,
+    ),
+)
+async def on_stream_closed(
+    msg: StreamClosedEvent, logger: Logger, event_id: str = EventIdDep
+) -> None:
+    logger.info("Received stream_closed event id=%s: %s", event_id, msg)

--- a/amsc-connector/uv.lock
+++ b/amsc-connector/uv.lock
@@ -120,6 +120,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "faststream", extra = ["cli", "redis"] },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -134,6 +135,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
+    { name = "faststream", extras = ["cli", "redis"], specifier = ">=0.6.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
@@ -727,6 +729,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fast-depends"
+version = "3.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/6d/787a21ca8043a8fdb737cf28f645e94a46fc30b44a31de54573299156bad/fast_depends-3.0.8.tar.gz", hash = "sha256:896b16f79a512b6ea1df721b0aa1708a192a06f964be6597e01fcf5412559101", size = 18382, upload-time = "2026-03-02T19:54:28.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/1d/e4843e4eeb65f51447b8c22d200d12d8f94f27c97e77bb7162515cc8d61f/fast_depends-3.0.8-py3-none-any.whl", hash = "sha256:4c52c8a3907bca46d43e70e4364d6d016872d9a3aae4bc0c1c85e72e0a6a21c7", size = 25507, upload-time = "2026-03-02T19:54:27.594Z" },
+]
+
+[package.optional-dependencies]
+pydantic = [
+    { name = "pydantic" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -864,6 +884,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/83/18/7a7c15657a3da5569b26fc51cde6a80f8d84cb54b3b1aea6d74a103db4ad/fastar-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:5744551bc67c6fc6581cbd0e34a0fd6e2cd0bd30b43e94b1c3119cf35064b162", size = 453601, upload-time = "2026-04-13T17:11:53.726Z" },
     { url = "https://files.pythonhosted.org/packages/6d/d8/331b59a6de279f3ad75c10c02c40a12f21d64a437d9c3d6f1af2dcbd7a76/fastar-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f4ce44e3b56c47cf38244b98d29f269b259740a580c47a2552efa5b96a5458fb", size = 486436, upload-time = "2026-04-13T17:11:40.089Z" },
     { url = "https://files.pythonhosted.org/packages/6b/fd/5390ec4f49100f3ecb9968a392f9e6d039f1e3fe0ecd28443716ff01e589/fastar-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:76c1359314355eafbc6989f20fb1ad565a3d10200117923b9da765a17e2f6f11", size = 461049, upload-time = "2026-04-13T17:11:25.918Z" },
+]
+
+[[package]]
+name = "faststream"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "fast-depends", extra = ["pydantic"] },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/7b/d02c069be0bc671b2eb8f805a1f824d2bfbe1852c9c3f4ad719a7ad3710b/faststream-0.6.7.tar.gz", hash = "sha256:c732eaf861c4cbddd9c7f9098608486a9f05dff67a72335686c3044039045346", size = 306185, upload-time = "2026-03-01T08:20:27.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/23/9d51f352fbb656f5345030f57e20737b1c88167f0eac354ac548d577808b/faststream-0.6.7-py3-none-any.whl", hash = "sha256:a904a4b1e3babeaa244a9460821f5b05dd71b00c959c816360b2acbbe267cd5c", size = 513454, upload-time = "2026-03-01T08:20:26.423Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "typer" },
+    { name = "watchfiles" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -2690,17 +2733,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.0"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
this adds redis connection. we will reuse the one tiled is using to transmit events on redis streams

the api layer is simply a passthru to redis.

we do this because we want persistence of our events and at-least-once processing so we don’t miss anything.

eventually if the event doesn’t process (e.g., amsc rejects it), we can put the events on a deadletter queue and do some reprocessing

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #63 
- <kbd>&nbsp;7&nbsp;</kbd> #62 
- <kbd>&nbsp;6&nbsp;</kbd> #61 
- <kbd>&nbsp;5&nbsp;</kbd> #60 
- <kbd>&nbsp;4&nbsp;</kbd> #58 
- <kbd>&nbsp;3&nbsp;</kbd> #57 
- <kbd>&nbsp;2&nbsp;</kbd> #55 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #54 
<!-- GitButler Footer Boundary Bottom -->

