### PR TITLE
feat: propagate dataset YAML keys to all nodes via INHERITED_KEYS

### DIFF
--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -43,6 +43,12 @@ from .utils import (
 # Callers can override via the max_workers kwarg on register_dataset_http.
 _DEFAULT_MAX_WORKERS = 8
 
+# Metadata keys propagated from the dataset YAML down to every entity
+# and artifact node, so per-node consumers (e.g. amsc-connector's
+# publish gate) can read the flag without walking the hierarchy.
+# Manifest columns of the same name win via setdefault.
+INHERITED_KEYS = ("amsc_public",)
+
 
 def create_data_source(art_row, base_dir, server_base_dir=None):
     """Create a Tiled DataSource for an artifact pointing to external HDF5.
@@ -117,7 +123,7 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
 
 def _register_one_entity(ent_row, ent_columns, art_grouped, art_columns,
                          parent_client, base_dir, server_base_dir,
-                         dataset_key):
+                         dataset_key, inherited=None):
     """Register a single entity container and its artifact children.
 
     Designed to be called from worker threads. Returns counter deltas so
@@ -128,6 +134,9 @@ def _register_one_entity(ent_row, ent_columns, art_grouped, art_columns,
         ent_added or skipped is 1; art_added counts artifacts successfully
         registered, art_failed counts artifacts that raised during register.
     """
+    if inherited is None:
+        inherited = {}
+
     uid = str(ent_row["uid"])
     ent_key = make_entity_key(ent_row, dataset_key)
 
@@ -150,6 +159,9 @@ def _register_one_entity(ent_row, ent_columns, art_grouped, art_columns,
             metadata[f"dataset_{art_key}"] = art_row["dataset"]
             if "index" in art_row.index and pd.notna(art_row.get("index")):
                 metadata[f"index_{art_key}"] = int(art_row["index"])
+
+    for k, v in inherited.items():
+        metadata.setdefault(k, v)
 
     # Create container with all metadata under dataset
     ent_container = parent_client.create_container(
@@ -175,6 +187,9 @@ def _register_one_entity(ent_row, ent_columns, art_grouped, art_columns,
                 for col in art_columns:
                     if col not in ARTIFACT_STANDARD_COLS:
                         art_metadata[col] = to_json_safe(art_row[col])
+
+                for k, v in inherited.items():
+                    art_metadata.setdefault(k, v)
 
                 ent_container.new(
                     structure_family=StructureFamily.array,
@@ -245,12 +260,15 @@ def register_dataset_http(client, ent_df, art_df, base_dir, label,
     ent_columns = list(ent_df.columns)
     art_columns = list(art_df.columns)
 
+    inherited = {k: dataset_metadata[k] for k in INHERITED_KEYS if k in dataset_metadata}
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [
             executor.submit(
                 _register_one_entity,
                 ent_row, ent_columns, art_grouped, art_columns,
                 parent_client, base_dir, server_base_dir, dataset_key,
+                inherited,
             )
             for _, ent_row in ent_df.iterrows()
         ]

--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -44,9 +44,9 @@ from .utils import (
 _DEFAULT_MAX_WORKERS = 8
 
 # Metadata keys propagated from the dataset YAML down to every entity
-# and artifact node, so per-node consumers (e.g. amsc-connector's
-# publish gate) can read the flag without walking the hierarchy.
-# Manifest columns of the same name win via setdefault.
+# and artifact node, so per-node consumers can read the flag without
+# walking the hierarchy. Manifest columns of the same name win via
+# setdefault.
 INHERITED_KEYS = ("amsc_public",)
 
 

--- a/tests/test_generic_registration.py
+++ b/tests/test_generic_registration.py
@@ -374,3 +374,81 @@ class TestGenericBehavior:
             for node in ent_nodes + art_nodes:
                 # Should not raise
                 json.dumps(node["metadata"])
+
+
+# ─── INHERITED_KEYS propagation (HTTP path) ──────────────────────────────────
+
+
+class TestInheritedKeysHTTP:
+    """Inherited dataset keys land on every entity and artifact node."""
+
+    def test_inherited_keys_propagate_to_entity_and_artifact(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from tiled_catalog_broker import http_register
+        from tiled_catalog_broker.http_register import _register_one_entity
+
+        monkeypatch.setattr(
+            http_register, "create_data_source",
+            lambda *a, **kw: (MagicMock(), (10,), "float64"),
+        )
+
+        ent_df = pd.DataFrame([{"uid": "e0001abc1234567", "Ja_meV": 1.0}])
+        art_df = pd.DataFrame([{
+            "uid": "e0001abc1234567",
+            "type": "rixs",
+            "file": "f.h5",
+            "dataset": "/x",
+        }])
+        art_grouped = art_df.groupby("uid")
+
+        parent_client = MagicMock()
+        parent_client.__contains__.return_value = False
+        ent_container = parent_client.create_container.return_value
+
+        result = _register_one_entity(
+            ent_df.iloc[0], list(ent_df.columns),
+            art_grouped, list(art_df.columns),
+            parent_client, base_dir="/tmp", server_base_dir=None,
+            dataset_key="TEST", inherited={"amsc_public": True},
+        )
+
+        assert result == (1, 1, 0, 0)
+
+        ent_meta = parent_client.create_container.call_args.kwargs["metadata"]
+        assert ent_meta["amsc_public"] is True
+
+        art_meta = ent_container.new.call_args.kwargs["metadata"]
+        assert art_meta["amsc_public"] is True
+
+    def test_manifest_value_wins_over_inherited(self, monkeypatch):
+        """setdefault semantics — manifest column with the same name wins."""
+        from unittest.mock import MagicMock
+        from tiled_catalog_broker import http_register
+        from tiled_catalog_broker.http_register import _register_one_entity
+
+        monkeypatch.setattr(
+            http_register, "create_data_source",
+            lambda *a, **kw: (MagicMock(), (10,), "float64"),
+        )
+
+        ent_df = pd.DataFrame([{"uid": "e0002abc1234567", "amsc_public": False}])
+        art_df = pd.DataFrame([{
+            "uid": "e0002abc1234567",
+            "type": "rixs",
+            "file": "f.h5",
+            "dataset": "/x",
+        }])
+        art_grouped = art_df.groupby("uid")
+
+        parent_client = MagicMock()
+        parent_client.__contains__.return_value = False
+
+        _register_one_entity(
+            ent_df.iloc[0], list(ent_df.columns),
+            art_grouped, list(art_df.columns),
+            parent_client, base_dir="/tmp", server_base_dir=None,
+            dataset_key="TEST", inherited={"amsc_public": True},
+        )
+
+        ent_meta = parent_client.create_container.call_args.kwargs["metadata"]
+        assert ent_meta["amsc_public"] is False


### PR DESCRIPTION
## Summary
- Stamps keys listed in `INHERITED_KEYS` (currently `amsc_public`) from `dataset_metadata` onto every entity and artifact at registration time, so per-node consumers (e.g. `amsc-connector` publish gate) can read the flag without walking the hierarchy. `setdefault` semantics — manifest values win on collision.
- Stacked on #66; will auto-retarget to `main` once #66 merges.

Closes #65

## Test plan
- [ ] Ingest with `amsc_public: true` in dataset YAML; confirm entity + artifact `amsc_public` is true via `/api/v1/metadata`.
- [ ] Ingest without the flag; confirm absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)