### PR TITLE
feat(cli): --max-workers flag + TCB_MAX_WORKERS env on tcb register

### DIFF
--- a/src/tiled_catalog_broker/cli.py
+++ b/src/tiled_catalog_broker/cli.py
@@ -10,6 +10,7 @@ Provides five commands:
   - tcb delete:         Delete registered data from a Tiled server
 """
 
+import os
 import sys
 import argparse
 from pathlib import Path
@@ -322,7 +323,21 @@ def register_main():
         metavar="NUM",
         help="Limit number of entities per dataset (default: all)",
     )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Concurrent registration workers "
+             "(default: TCB_MAX_WORKERS env var, or 8)",
+    )
     args = parser.parse_args()
+
+    max_workers = args.max_workers
+    if max_workers is None:
+        env_val = os.environ.get("TCB_MAX_WORKERS")
+        if env_val:
+            max_workers = int(env_val)
 
     import pandas as pd
     from tiled_catalog_broker.utils import check_server, get_artifact_info
@@ -384,10 +399,15 @@ def register_main():
 
         dataset_metadata = _build_dataset_metadata(config, label)
 
+        kwargs = {}
+        if max_workers is not None:
+            kwargs["max_workers"] = max_workers
+
         register_dataset_http(client, ent_df, art_df, base_dir, label,
                               dataset_key=dataset_key,
                               dataset_metadata=dataset_metadata,
-                              server_base_dir=server_base_dir)
+                              server_base_dir=server_base_dir,
+                              **kwargs)
 
     # Verify
     verify_registration_http(client)


### PR DESCRIPTION
## Summary
- Adds `--max-workers N` flag and `TCB_MAX_WORKERS` env var to `tcb register`.
- Precedence: `--max-workers` > `TCB_MAX_WORKERS` > library default 8.
- Stacked on #66 — that PR added the `max_workers` kwarg plumbing on `register_dataset_http`; this PR delivers the actual user-facing knob.

Refs #64

## Test plan
- [ ] `tcb register --help` shows `--max-workers N`.
- [ ] `TCB_MAX_WORKERS=4 tcb register tiny.yml` runs with pool=4.
- [ ] `--max-workers 4` overrides `TCB_MAX_WORKERS=16`.
- [ ] Default (neither set) still uses pool=8.