### PR TITLE
Default HDF5 mimetype to LazyHDF5ArrayAdapter (re-merge of #47)

### DIFF
--- a/src/tiled_catalog_broker/bulk_register.py
+++ b/src/tiled_catalog_broker/bulk_register.py
@@ -208,7 +208,7 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir, dataset_key):
                         to_json_safe(art_row["mimetype"])
                         if "mimetype" in art_df.columns
                         and pd.notna(art_row.get("mimetype"))
-                        else "application/x-hdf5"
+                        else "application/x-hdf5-broker"
                     ),
                 })
 

--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -82,13 +82,16 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
     if index is not None:
         ds_params["slice"] = str(int(index))
 
-    # Create data source
+    # Create data source. Default dispatches to the broker's
+    # LazyHDF5ArrayAdapter (server config must map it) — reads only the
+    # bytes a user slice asks for, unlike stock application/x-hdf5 which
+    # pulls the whole dataset into dask before slicing.
     data_source = DataSource(
         mimetype=(
             to_json_safe(art_row["mimetype"])
             if "mimetype" in art_row.index
             and pd.notna(art_row.get("mimetype"))
-            else "application/x-hdf5"
+            else "application/x-hdf5-broker"
         ),
         assets=[asset],
         structure_family=StructureFamily.array,


### PR DESCRIPTION
## Summary

Re-applies the content of #47 directly against `main`. The original PR was rebase-merged but landed on a stale base branch (`fix/metadata-check-core`) instead of main, so the change never reached the trunk.

`create_data_source` (and the `bulk_register` twin) defaulted to `application/x-hdf5`, which dispatches to tiled's stock HDF5 adapter. That adapter reads the full HDF5 dataset into memory before applying the user's slice — fine for one-shot full reads, painful for any Mode B slicing workflow.

Default to `application/x-hdf5-broker` instead, which the server maps to `LazyHDF5ArrayAdapter` (direct `h5py` slicing). Per-artifact `mimetype` columns in the manifest still win if set.

Requires server-side `adapters_by_mimetype` entry for `application/x-hdf5-broker` (already configured).

Closes #44
