### PR TITLE
Per-YAML server_base_dir, derived at inspect time (re-merge of #49)

### DIFF
--- a/src/tiled_catalog_broker/bulk_register.py
+++ b/src/tiled_catalog_broker/bulk_register.py
@@ -84,7 +84,8 @@ def init_database(db_path, readable_storage):
     return engine
 
 
-def prepare_node_data(ent_df, art_df, max_entities, base_dir, dataset_key):
+def prepare_node_data(ent_df, art_df, max_entities, base_dir, dataset_key,
+                      server_base_dir=None):
     """Prepare all node data for bulk insert.
 
     Reads all metadata columns dynamically from manifests -- no hardcoded
@@ -94,9 +95,12 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir, dataset_key):
         ent_df: Entity manifest DataFrame.
         art_df: Artifact manifest DataFrame.
         max_entities: Maximum number of entities to process.
-        base_dir: Base directory for resolving relative file paths.
+        base_dir: Authoring-host directory for resolving relative file paths.
         dataset_key: Dataset container key (slug of label); entity keys
             are derived as ``f"{dataset_key}_{uid[:12]}"``.
+        server_base_dir: Optional server-side mount path. If set, becomes
+            the asset `data_uri` base. Pre-computed by `tcb inspect` and
+            persisted in the YAML's `data.server_base_dir:`.
 
     Returns:
         ent_nodes: List of entity node dicts
@@ -146,7 +150,8 @@ def prepare_node_data(ent_df, art_df, max_entities, base_dir, dataset_key):
             for _, art_row in artifacts.iterrows():
                 art_key = make_artifact_key(art_row)
                 h5_rel_path = art_row["file"]
-                h5_full_path = os.path.realpath(os.path.join(base_dir, h5_rel_path))
+                uri_base = server_base_dir if server_base_dir else base_dir
+                h5_full_path = os.path.join(uri_base, h5_rel_path)
                 dataset_path = art_row["dataset"]
                 index = None
                 if "index" in art_df.columns and pd.notna(art_row.get("index")):

--- a/src/tiled_catalog_broker/cli.py
+++ b/src/tiled_catalog_broker/cli.py
@@ -267,6 +267,7 @@ def ingest_main():
         base_dir = config.get("base_dir")
         if base_dir is None and "data" in config:
             base_dir = config["data"].get("directory")
+        server_base_dir = config.get("data", {}).get("server_base_dir") or None
 
         # Clear shape cache between datasets
         get_artifact_info.__defaults__[-1].clear()
@@ -289,6 +290,7 @@ def ingest_main():
         ent_nodes, art_nodes, art_data_sources = prepare_node_data(
             ent_df, art_df, max_entities=n, base_dir=base_dir,
             dataset_key=dataset_key,
+            server_base_dir=server_base_dir,
         )
         bulk_register(engine, ent_nodes, art_nodes, art_data_sources,
                       dataset_key=dataset_key, dataset_metadata=dataset_metadata)
@@ -362,6 +364,7 @@ def register_main():
         base_dir = config.get("base_dir")
         if base_dir is None and "data" in config:
             base_dir = config["data"].get("directory")
+        server_base_dir = config.get("data", {}).get("server_base_dir") or None
 
         ent_path, art_path = _find_manifests(config_path, label, name)
         if ent_path is None or art_path is None:
@@ -383,7 +386,8 @@ def register_main():
 
         register_dataset_http(client, ent_df, art_df, base_dir, label,
                               dataset_key=dataset_key,
-                              dataset_metadata=dataset_metadata)
+                              dataset_metadata=dataset_metadata,
+                              server_base_dir=server_base_dir)
 
     # Verify
     verify_registration_http(client)

--- a/src/tiled_catalog_broker/config.py
+++ b/src/tiled_catalog_broker/config.py
@@ -89,3 +89,25 @@ def get_api_key():
     return os.environ.get("TILED_API_KEY", os.environ.get("TILED_KEY", ""))
 
 
+def get_host_data_root():
+    """Authoring-host filesystem root from `TILED_HOST_DATA_ROOT`.
+
+    The shared parent under which all dataset `directory:` paths sit on
+    the host running `tcb inspect`. `tcb inspect` uses this to derive a
+    `server_base_dir:` for the draft YAML when the Tiled server sees the
+    same data at a different mount.
+    """
+    return os.environ.get("TILED_HOST_DATA_ROOT", "")
+
+
+def get_server_data_root():
+    """Server-side mount root from `TILED_SERVER_DATA_ROOT`.
+
+    The same shared parent as `TILED_HOST_DATA_ROOT`, but as the Tiled
+    server sees it (K8s pod, reverse-proxy, etc.). `tcb inspect` swaps
+    this prefix into the YAML's `server_base_dir:` so registration is
+    purely read-only of the YAML.
+    """
+    return os.environ.get("TILED_SERVER_DATA_ROOT", "")
+
+

--- a/src/tiled_catalog_broker/http_register.py
+++ b/src/tiled_catalog_broker/http_register.py
@@ -39,10 +39,14 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
 
     Args:
         art_row: DataFrame row with artifact manifest columns.
-        base_dir: Base directory for resolving relative file paths (local).
-        server_base_dir: If provided, used for the asset data_uri instead of
-            base_dir.  Needed when the server sees the filesystem at a
-            different mount point (e.g. K8s pod).
+        base_dir: Base directory for resolving relative file paths on the
+            authoring host (used by `tcb generate` and Mode A reads).
+        server_base_dir: Optional server-side mount path. If set, becomes
+            the asset `data_uri` base — needed when the Tiled server sees
+            the filesystem at a different mount than the authoring host
+            (K8s pod, reverse proxy). Pre-computed by `tcb inspect` from
+            `TILED_HOST_DATA_ROOT` / `TILED_SERVER_DATA_ROOT` env vars
+            and persisted in the YAML's `data.server_base_dir:` field.
 
     Returns:
         Tuple of (DataSource, data_shape, data_dtype).
@@ -52,9 +56,9 @@ def create_data_source(art_row, base_dir, server_base_dir=None):
     from tiled.structures.data_source import Asset, DataSource, Management
 
     h5_rel_path = art_row["file"]
-    uri_base = server_base_dir if server_base_dir is not None else base_dir
-    h5_full_path = os.path.join(uri_base, h5_rel_path)
     dataset_path = art_row["dataset"]
+    uri_base = server_base_dir if server_base_dir else base_dir
+    h5_full_path = os.path.join(uri_base, h5_rel_path)
 
     # Determine index for batched files
     index = None

--- a/src/tiled_catalog_broker/tools/inspect.py
+++ b/src/tiled_catalog_broker/tools/inspect.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 import h5py
 import numpy as np
 
+from ..config import get_host_data_root, get_server_data_root
 from .schema import load_catalog_model, get_allowed_values
 
 
@@ -519,6 +520,23 @@ def emit_draft_yaml(result, output_path=None):
     w(f"  layout: {result.layout}")
     if result.layout == "batched":
         w(f"  # batch_size: {result.batch_size}")
+
+    # server_base_dir: server-side mount path. Auto-derived when both env
+    # vars are set and the source directory sits under TILED_HOST_DATA_ROOT;
+    # otherwise emitted as an empty TODO for the user to fill in.
+    host_root = get_host_data_root()
+    server_root = get_server_data_root()
+    server_base_dir = ""
+    if host_root and server_root:
+        host_norm = host_root.rstrip("/") + "/"
+        dir_norm = result.source_dir.rstrip("/") + "/"
+        if dir_norm.startswith(host_norm):
+            rel = dir_norm[len(host_norm):]
+            server_base_dir = (server_root.rstrip("/") + "/" + rel).rstrip("/")
+    if server_base_dir:
+        w(f"  server_base_dir: {server_base_dir}")
+    else:
+        w('  server_base_dir: ""  # TODO: server-side mount path; leave empty if Tiled sees the same paths as the host')
     w()
 
     # Parameters

--- a/src/tiled_catalog_broker/tools/schema.py
+++ b/src/tiled_catalog_broker/tools/schema.py
@@ -193,6 +193,12 @@ def validate(cfg, model_path=None):
         if not data.get("file_pattern"):
             warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
 
+        sbd = data.get("server_base_dir")
+        if sbd is not None and sbd != "" and not isinstance(sbd, str):
+            errors.append(
+                f"'data.server_base_dir' must be a string if set, got {type(sbd).__name__}"
+            )
+
     # --- Artifacts ---
     artifacts = cfg.get("artifacts", [])
     if not artifacts:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,3 +105,27 @@ class TestGetApiKey:
             os.environ["TILED_API_KEY"] = old_val
         if old_key:
             os.environ["TILED_KEY"] = old_key
+
+
+class TestDataRootEnv:
+    """Authoring-time env vars used by `tcb inspect` to derive server_base_dir."""
+
+    def test_unset_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("TILED_HOST_DATA_ROOT", raising=False)
+        monkeypatch.delenv("TILED_SERVER_DATA_ROOT", raising=False)
+        from tiled_catalog_broker.config import (
+            get_host_data_root,
+            get_server_data_root,
+        )
+        assert get_host_data_root() == ""
+        assert get_server_data_root() == ""
+
+    def test_set_returns_value(self, monkeypatch):
+        monkeypatch.setenv("TILED_HOST_DATA_ROOT", "/sdf/data/lcls/ds/prj/prjmaiqmag01/results/")
+        monkeypatch.setenv("TILED_SERVER_DATA_ROOT", "/prjmaiqmag01/")
+        from tiled_catalog_broker.config import (
+            get_host_data_root,
+            get_server_data_root,
+        )
+        assert get_host_data_root() == "/sdf/data/lcls/ds/prj/prjmaiqmag01/results/"
+        assert get_server_data_root() == "/prjmaiqmag01/"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -176,6 +176,36 @@ class TestEmitDraftYaml:
         assert "tcb stamp-key" in yaml_str
         assert "BROAD_SIGMA" in yaml_str  # example shown in the comment
 
+    def test_server_base_dir_placeholder_when_env_unset(self, batched_dir, monkeypatch):
+        """No env vars -> empty `server_base_dir:` placeholder with TODO."""
+        monkeypatch.delenv("TILED_HOST_DATA_ROOT", raising=False)
+        monkeypatch.delenv("TILED_SERVER_DATA_ROOT", raising=False)
+        result = inspect_directory(batched_dir)
+        yaml_str = emit_draft_yaml(result)
+        assert 'server_base_dir: ""' in yaml_str
+        assert "TODO" in yaml_str.split('server_base_dir: ""')[1].splitlines()[0]
+
+    def test_server_base_dir_filled_when_env_matches(self, batched_dir, monkeypatch):
+        """Env vars set + directory under host root -> auto-derived server_base_dir."""
+        host_root = str(batched_dir.parent) + "/"
+        monkeypatch.setenv("TILED_HOST_DATA_ROOT", host_root)
+        monkeypatch.setenv("TILED_SERVER_DATA_ROOT", "/srv/")
+        result = inspect_directory(batched_dir)
+        yaml_str = emit_draft_yaml(result)
+        # The dataset's host path is {parent}/{batched_dir.name}; under /srv/
+        # that should be /srv/{batched_dir.name}.
+        assert f"server_base_dir: /srv/{batched_dir.name}" in yaml_str
+
+    def test_server_base_dir_placeholder_when_directory_outside_root(
+        self, batched_dir, monkeypatch
+    ):
+        """Env set but directory outside host root -> empty placeholder."""
+        monkeypatch.setenv("TILED_HOST_DATA_ROOT", "/somewhere/else/")
+        monkeypatch.setenv("TILED_SERVER_DATA_ROOT", "/srv/")
+        result = inspect_directory(batched_dir)
+        yaml_str = emit_draft_yaml(result)
+        assert 'server_base_dir: ""' in yaml_str
+
     def test_emit_draft_yaml_no_round_in_provenance(self, batched_dir):
         """Provenance section doesn't mention 'round:' or 'prior_distribution:'."""
         result = inspect_directory(batched_dir)


### PR DESCRIPTION
## Summary

Re-applies the content of #49 directly against `main`. The original PR was rebase-merged but landed on a stale base branch (`chore/hoist-imports`) instead of main.

- `tcb inspect` reads `TILED_HOST_DATA_ROOT` + `TILED_SERVER_DATA_ROOT` (two simple env vars, no DSL parsing) and writes a concrete `server_base_dir:` into the draft YAML when the source directory sits under `TILED_HOST_DATA_ROOT`. Otherwise emits an empty `server_base_dir: ""  # TODO` placeholder.
- `tcb register` and `tcb ingest` are read-only over the YAML — `cli.py` reads `data.server_base_dir` and forwards it to `register_dataset_http` / `prepare_node_data` (the latter newly accepts the parameter; it was missing).
- Drops `realpath()` from `bulk_register` for parity with the http path.

Closes #45
