### PR TITLE
refactor: validate dataset YAML via pydantic contract models

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,83 @@
+# Tiled Catalog Broker
+
+A config-driven system for registering multi-modal scientific HDF5 datasets into a
+Tiled catalog so they can be consistently registered and discovered. The broker is
+**dataset-agnostic** but **not structure-agnostic**: producers must shape their data to
+one of a small, fixed set of supported layouts.
+
+## Language
+
+### Hierarchy
+
+**Dataset**:
+A top-level container (VDP, EDRIXS, SUNNY, ...) with provenance metadata. Holds entities.
+_Avoid_: collection, repo.
+
+**Entity**:
+A container whose physics parameters are queryable metadata; the unit a query selects.
+_Avoid_: sample, record, row.
+
+**Artifact**:
+An array child of an entity (a spectrum, a magnetization curve). The thing arrays load from.
+_Avoid_: observable (that's the physics word; in the catalog it's an artifact), output.
+
+### Onboarding
+
+**Onboarding**:
+The end-to-end process of taking a producer's HDF5 dataset and registering it into the
+catalog. Target flow: author a dataset YAML (agent or human, against the contract surface)
+→ `tcb generate` (manifests) → `tcb register`. There is a **single registration route**
+(HTTP `tcb register`); the bulk SQL path (`tcb ingest`) is removed (ADR-0002). `tcb inspect`
+is removed — its job is replaced by the contract surface (see below).
+_Avoid_: ingest (removed), inspect (removed).
+
+**Layout**:
+The physical on-disk arrangement of a dataset's HDF5 files. Exactly **three** are
+supported and this set is frozen (see ADR-0001):
+- `per_entity` — one HDF5 file per entity; scalars are parameters.
+- `batched` — entities stacked along axis-0 of datasets within each file.
+- `grouped` — one HDF5 group per entity inside a single file.
+_Avoid_: format, structure (reserve "structure" for the broader data contract).
+
+**Data contract**:
+The full set of rules a producer's data + YAML must satisfy to be onboarded: one of the
+three layouts, the YAML field contract, and the controlled vocabulary. "We tell users
+their data must follow this — we do not support arbitrary configurations."
+
+**Dataset YAML**:
+The per-dataset config file that declares identity, layout, artifacts, parameters, and
+metadata. The human-and-agent-authored input contract; the Parquet manifest is the output.
+
+**Semantic model**:
+The controlled vocabulary in `tools/schema/catalog_model.yml` — canonical ids (and
+aliases) for `method`, `material`, `producer`, `project`, `facility`, `data_type`. It keeps
+cross-dataset discovery (`Key("project") == "MAIQMag"`) honest. It is **soft**: unknown
+values warn (not error), aliases normalize to canonical ids (ADR-0003). It is a
+normalization + reference layer, not a rigid gate.
+_Avoid_: schema (overloaded — the structural pydantic models are also a "schema").
+
+**Contract surface**:
+The referenceable artifacts that define what a valid dataset is — the pydantic YAML
+models, the semantic model, the layout definitions, the YAML-contract doc, and the
+example `datasets/*.yml`. The onboarding principle is **implementation vs. contract**: an
+agent (or human) onboards by reading the *contract surface*, never by reading broker
+*implementation* (`inspect.py`, `generate.py`, `http_register.py`). Today the contract is
+trapped inside implementation behavior; this effort lifts it onto the contract surface.
+_Avoid_: "source" (ambiguous — distinguish contract artifacts from implementation code).
+
+## Relationships
+
+- A **Dataset** contains one or more **Entities**; an **Entity** contains one or more **Artifacts**.
+- A **Dataset YAML** describes exactly one **Dataset** and declares its **Layout**.
+- The **Semantic model** constrains the metadata vocabulary used across all **Datasets**.
+
+## Flagged ambiguities
+
+- **Controlled-vocabulary drift (resolved).** The #72 study found agents without sight of
+  the semantic model independently invented `measurement` (use **`method`**),
+  `organization` (use **`project`**), and `Sunny.jl` (use the canonical id **`sunny_jl`**).
+  These synonyms break cross-dataset queries; the semantic model's canonical ids are
+  authoritative.
+- **"schema"** is overloaded: it means both the structural contract (pydantic models in
+  `tools/_models.py`) and, loosely, the semantic vocabulary. Prefer **semantic model** for
+  the vocabulary and **YAML contract / pydantic models** for structure.

--- a/docs/adr/0001-fixed-set-of-three-layouts.md
+++ b/docs/adr/0001-fixed-set-of-three-layouts.md
@@ -1,0 +1,15 @@
+# Fixed set of three supported layouts
+
+The broker supports exactly three dataset **layouts** — `per_entity`, `batched`, and
+`grouped` — and treats this set as frozen. New layouts require a new ADR.
+
+We chose this over (a) collapsing to a single canonical layout and (b) accepting arbitrary
+producer arrangements. A single layout would force every producer to physically reshape
+existing data (including the 19.5 GB grouped Zhantao set from the #72 study); arbitrary
+layouts are what make `tcb inspect`/`tcb generate` complex and is explicitly out of scope
+("we do not support an arbitrary number of dataset configurations"). Three fixed layouts
+cover the real producer data we have while keeping the data contract small enough to
+document precisely and onboard against — by an agent or a human — without code reference.
+
+Consequence: the cost of matching a layout moves to the producer (documented up front),
+not to broker heuristics that guess at structure.

--- a/docs/adr/0002-single-registration-route.md
+++ b/docs/adr/0002-single-registration-route.md
@@ -1,0 +1,17 @@
+# Single registration route (HTTP), bulk SQL path removed
+
+Onboarding converges on one registration route: `tcb register` (the HTTP path via
+`http_register.py`). The bulk SQL path (`tcb ingest` / `bulk_register.py`, ~546 lines) is
+removed, and `tests/test_generic_registration.py` is migrated off `prepare_node_data`.
+
+`bulk_register` only ever existed as a performance workaround — its own docstring says it
+"will be removed once HTTP registration performance is sufficient for all use cases." The
+#66 parallelization (per-entity `ThreadPoolExecutor`, targeting the socket-recv bottleneck)
+was the work to close that gap. Two registration routes for the same job is exactly the
+complexity this simplification targets, and the contract (the Parquet manifest) is
+identical for both, so nothing in the data model is lost.
+
+Condition / verification gate: before deleting `bulk_register.py`, confirm `tcb register`
+handles the bulk case (10k–100k entities) at acceptable speed post-#66. If unproven, that
+benchmark is a step in the removal PR. The stale "when (not) to use" headers in both
+`http_register.py` and `bulk_register.py` are reconciled in the same PR.

--- a/docs/adr/0003-vocabulary-is-soft-normalization.md
+++ b/docs/adr/0003-vocabulary-is-soft-normalization.md
@@ -13,9 +13,9 @@ controlled vocab becomes one facet among several rather than a checkpoint. #72 f
 vocab's value is as a consistency/teaching tool, not a gate; hard enforcement would
 contradict that and foreclose the flexible-discovery direction.
 
-Consequence / cleanup: the `dataset_fields` section of `catalog_model.yml` currently
-*declares* `data_type`/`method` as "required" with `enum_ref`s, but the validator does not
-enforce that (it warns) and the field→vocab mapping is hardcoded in `schema.py` instead.
-That section is decorative and contradicts actual enforcement — it should be corrected to
-describe what the code really does (advisory), not expanded into a real gate. A pydantic
-model of the vocab file's own shape is deferred (low value until the file is edited widely).
+Consequence: field *presence* and field *value* are enforced separately. `_models.py`
+hard-requires the **presence** of `data_type`, `method`, and `material` (a config missing
+one errors), and `catalog_model.yml`'s `dataset_fields: required` list now matches that set.
+What stays **soft is the value** — an out-of-vocab `material` validates with only a warning,
+per this ADR. The field→vocab mapping that drives those warnings still lives in `schema.py`;
+a pydantic model of the vocab file's own shape is deferred (low value until it's edited widely).

--- a/docs/adr/0003-vocabulary-is-soft-normalization.md
+++ b/docs/adr/0003-vocabulary-is-soft-normalization.md
@@ -1,0 +1,21 @@
+# Controlled vocabulary is soft normalization, not a rigid gate
+
+The semantic model (`catalog_model.yml`) stays **soft**: unknown metadata values produce
+**warnings**, not errors, and known aliases are rewritten to canonical ids
+(`resolve_aliases`). We deliberately do **not** make the vocabulary a hard gate that
+rejects novel values.
+
+The vocabulary's job is to keep **structured/faceted queries reliable** — so `NiPS3`,
+`NIPS`, and `nips3` collapse to one facet rather than fragmenting `Key("material") == ...`.
+Canonical ids + aliases achieve that without blocking new values. This is also what keeps
+the door open to **more flexible discovery** (semantic/embedding search) later, where the
+controlled vocab becomes one facet among several rather than a checkpoint. #72 found the
+vocab's value is as a consistency/teaching tool, not a gate; hard enforcement would
+contradict that and foreclose the flexible-discovery direction.
+
+Consequence / cleanup: the `dataset_fields` section of `catalog_model.yml` currently
+*declares* `data_type`/`method` as "required" with `enum_ref`s, but the validator does not
+enforce that (it warns) and the field→vocab mapping is hardcoded in `schema.py` instead.
+That section is decorative and contradicts actual enforcement — it should be corrected to
+describe what the code really does (advisory), not expanded into a real gate. A pydantic
+model of the vocab file's own shape is deferred (low value until the file is edited widely).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tiled-catalog-broker"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "pandas",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "ruamel.yaml",
     "canonicaljson",
     "sqlalchemy",
+    "pydantic>=2",
     "tiled[server]",
 ]
 

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -1,0 +1,129 @@
+"""Pydantic models for the dataset YAML contract.
+
+These models declare the *structural* contract of a dataset config: required fields,
+allowed enum values, and conditional requirements. They are part of the **contract
+surface** (see CONTEXT.md) — an agent or human can read this file to learn what a valid
+dataset YAML looks like, without reading broker implementation.
+
+Two things stay in ``schema.py`` layered on top of a successful parse, by design:
+
+- Controlled-vocabulary checks (``method``/``material``/``producer``/... against
+  ``catalog_model.yml``) — these are non-fatal *warnings*, not errors (ADR-0003).
+- Filesystem checks (does ``data.directory`` exist) — environment-dependent, so keeping
+  them out of the model lets a config be validated without its data present.
+
+Conventions follow ``amsc-connector/core/_models.py`` (pydantic v2, ``ConfigDict``,
+``@model_validator``). The broker targets Python >=3.10, so enums use ``(str, Enum)``
+rather than ``StrEnum`` (3.11+).
+
+Strictness: the closed sub-sections (``data``, ``artifacts``, ``parameters``, ``shared``)
+``forbid`` unknown keys to catch typos. ``metadata`` is extensible so it ``allow``s extras;
+the top level ``ignore``s extras for keys that carry no structural rules (``provenance``,
+``extra_metadata``, ``artifact_datasets``). Required strings use ``min_length=1`` so an
+empty string is treated as missing, matching the prior validator.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class Layout(str, Enum):
+    """Allowed values for ``data.layout`` (ADR-0001 — frozen set of three)."""
+
+    per_entity = "per_entity"
+    batched = "batched"
+    grouped = "grouped"
+
+
+class ParamLocation(str, Enum):
+    """Allowed values for ``parameters.location``."""
+
+    root_scalars = "root_scalars"
+    root_attributes = "root_attributes"
+    group = "group"
+    group_scalars = "group_scalars"
+    manifest = "manifest"
+
+
+class DatasetMetadata(BaseModel):
+    # Dataset metadata is extensible — datasets add their own keys (e.g.
+    # prior_distribution, round), so allow extras. Vocabulary is checked as
+    # warnings in schema.py, not here; every field is optional.
+    model_config = ConfigDict(extra="allow")
+
+    method: list[str] | None = None
+    data_type: str | None = None
+    material: str | None = None
+    producer: str | None = None
+    project: str | None = None
+    facility: str | None = None
+
+
+class DataSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    directory: str = Field(min_length=1)
+    layout: Layout
+    file_pattern: str | None = None
+    server_base_dir: str | None = None
+
+
+class ArtifactSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(min_length=1)
+    dataset: str = Field(min_length=1)
+
+
+class SharedAxisSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(min_length=1)
+    dataset: str = Field(min_length=1)
+
+
+class ParametersSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    location: ParamLocation | None = None
+    group: str | None = None
+    manifest: str | None = None
+
+    @model_validator(mode="after")
+    def _location_requirements(self):
+        if self.location == ParamLocation.group and not self.group:
+            raise ValueError("'parameters.group' is required when location is 'group'")
+        if self.location == ParamLocation.manifest and not self.manifest:
+            raise ValueError(
+                "'parameters.manifest' is required when location is 'manifest'"
+            )
+        return self
+
+
+class DatasetConfig(BaseModel):
+    """Top-level dataset YAML contract.
+
+    Unknown top-level keys (``provenance``, ``extra_metadata``, ``artifact_datasets``) are
+    ignored: they carry no structural rules today and are consumed downstream from the raw
+    config dict, not from this model.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    label: str = Field(min_length=1)
+    key: str | None = None
+    key_prefix: str | None = None
+    metadata: DatasetMetadata = Field(default_factory=DatasetMetadata)
+    data: DataSection
+    artifacts: list[ArtifactSpec] = Field(min_length=1)
+    parameters: ParametersSection | None = None
+    shared: list[SharedAxisSpec] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _require_identity(self):
+        if not self.key and not self.key_prefix:
+            raise ValueError(
+                "'key' is required (dataset container key in Tiled), or set 'key_prefix'"
+            )
+        return self

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -137,8 +137,7 @@ class SharedAxisSpec(BaseModel):
 class ParametersSection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    location: ParamLocation | None = Field(
-        default=None,
+    location: ParamLocation = Field(
         description="Where to read per-entity parameters from; see ParamLocation.",
     )
     group: str | None = Field(
@@ -189,8 +188,7 @@ class DatasetConfig(BaseModel):
         min_length=1,
         description="The array artifacts each entity exposes (at least one).",
     )
-    parameters: ParametersSection | None = Field(
-        default=None,
+    parameters: ParametersSection = Field(
         description="How to extract each entity's physics parameters from the HDF5.",
     )
     shared: list[SharedAxisSpec] = Field(

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -89,6 +89,9 @@ class ParametersSection(BaseModel):
     location: ParamLocation | None = None
     group: str | None = None
     manifest: str | None = None
+    # The HDF5 group holding one subgroup per entity (grouped layout). Optional;
+    # the generator falls back to "samples", then to top-level groups.
+    entity_group: str | None = None
 
     @model_validator(mode="after")
     def _location_requirements(self):

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -43,7 +43,6 @@ class ParamLocation(str, Enum):
     root_attributes = "root_attributes"
     group = "group"
     group_scalars = "group_scalars"
-    manifest = "manifest"
 
 
 class DatasetMetadata(BaseModel):
@@ -88,7 +87,6 @@ class ParametersSection(BaseModel):
 
     location: ParamLocation | None = None
     group: str | None = None
-    manifest: str | None = None
     # The HDF5 group holding one subgroup per entity (grouped layout). Optional;
     # the generator falls back to "samples", then to top-level groups.
     entity_group: str | None = None
@@ -97,10 +95,6 @@ class ParametersSection(BaseModel):
     def _location_requirements(self):
         if self.location == ParamLocation.group and not self.group:
             raise ValueError("'parameters.group' is required when location is 'group'")
-        if self.location == ParamLocation.manifest and not self.manifest:
-            raise ValueError(
-                "'parameters.manifest' is required when location is 'manifest'"
-            )
         return self
 
 

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -3,7 +3,8 @@
 These models declare the *structural* contract of a dataset config: required fields,
 allowed enum values, and conditional requirements. They are part of the **contract
 surface** (see CONTEXT.md) — an agent or human can read this file to learn what a valid
-dataset YAML looks like, without reading broker implementation.
+dataset YAML looks like, without reading broker implementation. Every field carries a
+``description`` so the contract is self-documenting (and surfaces in the JSON schema).
 
 Two things stay in ``schema.py`` layered on top of a successful parse, by design:
 
@@ -13,8 +14,7 @@ Two things stay in ``schema.py`` layered on top of a successful parse, by design
   them out of the model lets a config be validated without its data present.
 
 Conventions follow ``amsc-connector/core/_models.py`` (pydantic v2, ``ConfigDict``,
-``@model_validator``). The broker targets Python >=3.10, so enums use ``(str, Enum)``
-rather than ``StrEnum`` (3.11+).
+``@model_validator``, ``StrEnum``). The broker targets Python >=3.12.
 
 Strictness: the closed sub-sections (``data``, ``artifacts``, ``parameters``, ``shared``)
 ``forbid`` unknown keys to catch typos. ``metadata`` is extensible so it ``allow``s extras;
@@ -23,21 +23,36 @@ the top level ``ignore``s extras for keys that carry no structural rules (``prov
 empty string is treated as missing, matching the prior validator.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class Layout(str, Enum):
-    """Allowed values for ``data.layout`` (ADR-0001 — frozen set of three)."""
+class Layout(StrEnum):
+    """How entities are physically packed in the HDF5 data (``data.layout``).
+
+    Frozen set of three (ADR-0001):
+
+    - ``per_entity`` — one HDF5 *file* per entity; parameters are scalars in that file.
+    - ``batched`` — many entities stacked along axis-0 of shared datasets within each
+      file; entity *i* is row *i* (e.g. ``/spectra`` has shape ``(N, 600)``).
+    - ``grouped`` — one HDF5 *group* per entity inside a file, each group self-contained
+      (e.g. ``/samples/sample_000/spectrum``).
+    """
 
     per_entity = "per_entity"
     batched = "batched"
     grouped = "grouped"
 
 
-class ParamLocation(str, Enum):
-    """Allowed values for ``parameters.location``."""
+class ParamLocation(StrEnum):
+    """Where a dataset's physics parameters are read from (``parameters.location``).
+
+    - ``root_scalars`` — scalar (0-dim) datasets at the file root.
+    - ``root_attributes`` — root-level HDF5 attributes (``f.attrs``).
+    - ``group`` — datasets inside a named group (which group: ``parameters.group``).
+    - ``group_scalars`` — scalar datasets inside each entity group (grouped layout).
+    """
 
     root_scalars = "root_scalars"
     root_attributes = "root_attributes"
@@ -47,49 +62,103 @@ class ParamLocation(str, Enum):
 
 class DatasetMetadata(BaseModel):
     # Dataset metadata is extensible — datasets add their own keys (e.g.
-    # prior_distribution, round), so allow extras. Vocabulary is checked as
-    # warnings in schema.py, not here; every field is optional.
+    # prior_distribution, round), so allow extras. method/data_type/material are
+    # required (presence); the rest are optional. *Values* are only soft-checked
+    # against the vocab as warnings in schema.py, never gated here (ADR-0003).
     model_config = ConfigDict(extra="allow")
 
-    method: list[str] | None = None
-    data_type: str | None = None
-    material: str | None = None
-    producer: str | None = None
-    project: str | None = None
-    facility: str | None = None
+    method: list[str] = Field(
+        min_length=1,
+        description="Scientific methods/observables, e.g. ['RIXS'] — at least one "
+        "required (values soft-checked against the vocab).",
+    )
+    data_type: str = Field(
+        min_length=1,
+        description="'simulation' or 'experimental' — required (value soft-checked).",
+    )
+    material: str = Field(
+        min_length=1,
+        description="Target material or system, e.g. 'NiPS3' — required (value soft-checked).",
+    )
+    producer: str | None = Field(
+        default=None,
+        description="Code that produced the data, e.g. 'edrixs' — typically for simulations.",
+    )
+    project: str | None = Field(
+        default=None,
+        description="Scientific project or collaboration (value soft-checked).",
+    )
+    facility: str | None = Field(
+        default=None,
+        description="Facility where data was collected — typically for experiments.",
+    )
 
 
 class DataSection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    directory: str = Field(min_length=1)
-    layout: Layout
-    file_pattern: str | None = None
-    server_base_dir: str | None = None
+    directory: str = Field(
+        min_length=1,
+        description="Filesystem path to the dataset's data root (where the HDF5 files live).",
+    )
+    layout: Layout = Field(
+        description="How entities are physically packed in the HDF5 data; see Layout.",
+    )
+    file_pattern: str | None = Field(
+        default=None,
+        description="Glob for HDF5 files under `directory` (defaults to '**/*.h5').",
+    )
+    server_base_dir: str | None = Field(
+        default=None,
+        description="Base directory the Tiled server resolves each file's data_uri "
+        "against (derived at inspect time).",
+    )
 
 
 class ArtifactSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    type: str = Field(min_length=1)
-    dataset: str = Field(min_length=1)
+    type: str = Field(
+        min_length=1,
+        description="Human-readable artifact name; becomes the array's key under its entity.",
+    )
+    dataset: str = Field(
+        min_length=1,
+        description="HDF5 path to the array. Resolved per layout: as-is for per_entity/"
+        "batched, relative to each entity group for grouped.",
+    )
 
 
 class SharedAxisSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    type: str = Field(min_length=1)
-    dataset: str = Field(min_length=1)
+    type: str = Field(
+        min_length=1,
+        description="Name of the shared axis, e.g. 'energy'; becomes its key under the dataset.",
+    )
+    dataset: str = Field(
+        min_length=1,
+        description="HDF5 path to a 1-D axis array shared by all entities (registered once).",
+    )
 
 
 class ParametersSection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    location: ParamLocation | None = None
-    group: str | None = None
-    # The HDF5 group holding one subgroup per entity (grouped layout). Optional;
-    # the generator falls back to "samples", then to top-level groups.
-    entity_group: str | None = None
+    location: ParamLocation | None = Field(
+        default=None,
+        description="Where to read per-entity parameters from; see ParamLocation.",
+    )
+    group: str | None = Field(
+        default=None,
+        description="HDF5 group path holding the parameter datasets; required when "
+        "location is 'group'.",
+    )
+    entity_group: str | None = Field(
+        default=None,
+        description="HDF5 group holding one subgroup per entity (grouped layout); the "
+        "generator falls back to 'samples', then to top-level groups.",
+    )
 
     @model_validator(mode="after")
     def _location_requirements(self):
@@ -108,19 +177,40 @@ class DatasetConfig(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    label: str = Field(min_length=1)
-    key: str | None = None
-    key_prefix: str | None = None
-    metadata: DatasetMetadata = Field(default_factory=DatasetMetadata)
-    data: DataSection
-    artifacts: list[ArtifactSpec] = Field(min_length=1)
-    parameters: ParametersSection | None = None
-    shared: list[SharedAxisSpec] = Field(default_factory=list)
+    label: str = Field(
+        min_length=1,
+        description="Human-readable dataset name; also the basis for the derived UID namespace.",
+    )
+    key: str | None = Field(
+        default=None,
+        description="Dataset container key in Tiled (human-readable, e.g. 'BROAD_SIGMA'); "
+        "required — written by `tcb stamp-key` as slug(label).",
+    )
+    metadata: DatasetMetadata = Field(
+        description="Dataset-level provenance and discovery metadata (queryable facets); "
+        "required (must carry method, data_type, material).",
+    )
+    data: DataSection = Field(
+        description="Where the data lives on disk and how its entities are laid out.",
+    )
+    artifacts: list[ArtifactSpec] = Field(
+        min_length=1,
+        description="The array artifacts each entity exposes (at least one).",
+    )
+    parameters: ParametersSection | None = Field(
+        default=None,
+        description="How to extract each entity's physics parameters from the HDF5.",
+    )
+    shared: list[SharedAxisSpec] = Field(
+        default_factory=list,
+        description="Axis arrays shared across all entities, registered once under the dataset.",
+    )
 
     @model_validator(mode="after")
-    def _require_identity(self):
-        if not self.key and not self.key_prefix:
+    def _require_key(self):
+        if not self.key:
             raise ValueError(
-                "'key' is required (dataset container key in Tiled), or set 'key_prefix'"
+                "'key' is required (dataset container key in Tiled); "
+                "run `tcb stamp-key` to derive it from the label"
             )
         return self

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -13,14 +13,11 @@ Two things stay in ``schema.py`` layered on top of a successful parse, by design
 - Filesystem checks (does ``data.directory`` exist) — environment-dependent, so keeping
   them out of the model lets a config be validated without its data present.
 
-Conventions follow ``amsc-connector/core/_models.py`` (pydantic v2, ``ConfigDict``,
-``@model_validator``, ``StrEnum``). The broker targets Python >=3.12.
-
 Strictness: the closed sub-sections (``data``, ``artifacts``, ``parameters``, ``shared``)
 ``forbid`` unknown keys to catch typos. ``metadata`` is extensible so it ``allow``s extras;
 the top level ``ignore``s extras for keys that carry no structural rules (``provenance``,
 ``extra_metadata``, ``artifact_datasets``). Required strings use ``min_length=1`` so an
-empty string is treated as missing, matching the prior validator.
+empty string is treated as missing.
 """
 
 from enum import StrEnum
@@ -61,10 +58,8 @@ class ParamLocation(StrEnum):
 
 
 class DatasetMetadata(BaseModel):
-    # Dataset metadata is extensible — datasets add their own keys (e.g.
-    # prior_distribution, round), so allow extras. method/data_type/material are
-    # required (presence); the rest are optional. *Values* are only soft-checked
-    # against the vocab as warnings in schema.py, never gated here (ADR-0003).
+    # Extensible — datasets add their own keys (e.g. prior_distribution), so allow
+    # extras. Values are soft-checked as warnings in schema.py, not gated (ADR-0003).
     model_config = ConfigDict(extra="allow")
 
     method: list[str] = Field(

--- a/src/tiled_catalog_broker/tools/_models.py
+++ b/src/tiled_catalog_broker/tools/_models.py
@@ -6,12 +6,9 @@ surface** (see CONTEXT.md) — an agent or human can read this file to learn wha
 dataset YAML looks like, without reading broker implementation. Every field carries a
 ``description`` so the contract is self-documenting (and surfaces in the JSON schema).
 
-Two things stay in ``schema.py`` layered on top of a successful parse, by design:
-
-- Controlled-vocabulary checks (``method``/``material``/``producer``/... against
-  ``catalog_model.yml``) — these are non-fatal *warnings*, not errors (ADR-0003).
-- Filesystem checks (does ``data.directory`` exist) — environment-dependent, so keeping
-  them out of the model lets a config be validated without its data present.
+Controlled-vocabulary checks (``method``/``material``/... against ``catalog_model.yml``)
+stay in ``schema.py`` layered on top of a successful parse — they are non-fatal *warnings*,
+not errors (ADR-0003).
 
 Strictness: the closed sub-sections (``data``, ``artifacts``, ``parameters``, ``shared``)
 ``forbid`` unknown keys to catch typos. ``metadata`` is extensible so it ``allow``s extras;
@@ -99,9 +96,9 @@ class DataSection(BaseModel):
     layout: Layout = Field(
         description="How entities are physically packed in the HDF5 data; see Layout.",
     )
-    file_pattern: str | None = Field(
-        default=None,
-        description="Glob for HDF5 files under `directory` (defaults to '**/*.h5').",
+    file_pattern: str = Field(
+        default="**/*.h5",
+        description="Glob for HDF5 files under `directory`.",
     )
     server_base_dir: str | None = Field(
         default=None,

--- a/src/tiled_catalog_broker/tools/schema.py
+++ b/src/tiled_catalog_broker/tools/schema.py
@@ -196,7 +196,6 @@ def validate(cfg, model_path=None):
     if not config.data.file_pattern:
         warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
 
-    # Dataset metadata: soft controlled-vocabulary checks (warnings only, ADR-0003).
     metadata = config.metadata
     if model:
         _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)

--- a/src/tiled_catalog_broker/tools/schema.py
+++ b/src/tiled_catalog_broker/tools/schema.py
@@ -4,45 +4,18 @@ Validates dataset YAML configs against both structural requirements
 and the semantic model (schema/catalog_model.yml).
 """
 
-import os
 from pathlib import Path
 
-from pydantic import ValidationError as PydanticValidationError
 from ruamel.yaml import YAML
 
 from ._models import DatasetConfig
 
 
-class ValidationError(Exception):
-    """Raised when a dataset YAML fails validation."""
-
-    def __init__(self, errors):
-        self.errors = errors
-        super().__init__(
-            f"{len(errors)} validation error(s):\n"
-            + "\n".join(f"  - {e}" for e in errors)
-        )
-
-
-def load_catalog_model(model_path=None):
-    """Load the semantic model YAML.
-
-    Args:
-        model_path: Path to catalog_model.yml.
-            Defaults to schema/catalog_model.yml relative to the package.
-
-    Returns:
-        dict: The parsed catalog model, or None if not found.
-    """
-    if model_path is None:
-        model_path = (
-            Path(__file__).parent / "schema" / "catalog_model.yml"
-        )
-    if not Path(model_path).exists():
-        return None
-
+def load_catalog_model():
+    """Load and parse the bundled semantic model (schema/catalog_model.yml)."""
+    path = Path(__file__).parent / "schema" / "catalog_model.yml"
     yaml = YAML()
-    with open(model_path) as f:
+    with open(path) as f:
         return yaml.load(f)
 
 
@@ -56,7 +29,7 @@ def get_allowed_values(model, field_name):
     Returns:
         list[str]: Allowed ID values, or empty list if not found.
     """
-    if model is None or field_name not in model:
+    if field_name not in model:
         return []
     return [entry["id"] for entry in model[field_name]]
 
@@ -74,7 +47,7 @@ def get_alias_map(model, field_name):
     Returns:
         dict: {alias_id: {"canonical": canonical_id, "implies": {...}}}
     """
-    if model is None or field_name not in model:
+    if field_name not in model:
         return {}
     alias_map = {}
     for entry in model[field_name]:
@@ -106,8 +79,6 @@ def resolve_aliases(cfg, model):
     Returns:
         list[str]: Messages about resolved aliases.
     """
-    if model is None:
-        return []
     messages = []
     metadata = cfg.get("metadata", {})
 
@@ -145,65 +116,28 @@ def resolve_aliases(cfg, model):
     return messages
 
 
-def _format_model_errors(exc):
-    """Translate a pydantic ValidationError into the broker's flat error strings.
-
-    Each pydantic error becomes a "<dotted.location>: <message>" line so the existing
-    ``ValidationError(errors)`` message format (and substring-based tests) keep working.
-    """
-    messages = []
-    for err in exc.errors():
-        loc = ".".join(str(p) for p in err["loc"])
-        msg = err["msg"].removeprefix("Value error, ")
-        messages.append(f"{loc}: {msg}" if loc else msg)
-    return messages
-
-
-def validate(cfg, model_path=None):
+def validate(cfg):
     """Validate a parsed dataset YAML config.
 
-    Args:
-        cfg: dict loaded from YAML.
-        model_path: Optional path to catalog_model.yml.
-
-    Returns:
-        list of warning strings (non-fatal).
-
-    Raises:
-        ValidationError: if required fields are missing or invalid.
+    Returns a list of non-fatal warning strings. Raises pydantic ``ValidationError``
+    if the config violates the structural contract.
     """
     warnings = []
-    model = load_catalog_model(model_path)
+    model = load_catalog_model()
 
     # Resolve aliases before validation (mutates cfg in place).
     warnings.extend(resolve_aliases(cfg, model))
 
-    # Structural validation via the pydantic contract model. Raise immediately —
-    # the filesystem/vocab checks below operate on the validated object.
-    # try/except is required here: pydantic raises a single ValidationError for all
-    # structural problems, which we translate into the broker's flat-list format.
-    try:
-        config = DatasetConfig.model_validate(cfg)
-    except PydanticValidationError as e:
-        raise ValidationError(_format_model_errors(e))
-
-    # Filesystem check (kept out of the pure model so a config can be validated
-    # without its data present — but enforced here when the directory is given).
-    if not os.path.isdir(config.data.directory):
-        raise ValidationError(
-            [f"'data.directory' does not exist: {config.data.directory}"]
-        )
-    if not config.data.file_pattern:
-        warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
+    # Structural validation — pydantic raises ValidationError on any violation.
+    config = DatasetConfig.model_validate(cfg)
 
     metadata = config.metadata
-    if model:
-        _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
-        _validate_vocab(metadata, "data_type", "data_types", model, warnings)
-        _validate_vocab(metadata, "material", "materials", model, warnings)
-        _validate_vocab(metadata, "producer", "producers", model, warnings)
-        _validate_vocab(metadata, "facility", "facilities", model, warnings)
-        _validate_vocab(metadata, "project", "projects", model, warnings)
+    _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
+    _validate_vocab(metadata, "data_type", "data_types", model, warnings)
+    _validate_vocab(metadata, "material", "materials", model, warnings)
+    _validate_vocab(metadata, "producer", "producers", model, warnings)
+    _validate_vocab(metadata, "facility", "facilities", model, warnings)
+    _validate_vocab(metadata, "project", "projects", model, warnings)
 
     # Cross-field advisory checks (producer↔simulation, facility↔experimental).
     dt = metadata.data_type

--- a/src/tiled_catalog_broker/tools/schema.py
+++ b/src/tiled_catalog_broker/tools/schema.py
@@ -172,37 +172,32 @@ def validate(cfg, model_path=None):
     Raises:
         ValidationError: if required fields are missing or invalid.
     """
-    errors = []
     warnings = []
     model = load_catalog_model(model_path)
 
-    # --- Resolve aliases before validation ---
-    alias_messages = resolve_aliases(cfg, model)
-    for msg in alias_messages:
-        warnings.append(msg)
+    # Resolve aliases before validation (mutates cfg in place).
+    warnings.extend(resolve_aliases(cfg, model))
 
-    # --- Structural validation via the pydantic contract model ---
+    # Structural validation via the pydantic contract model. Raise immediately —
+    # the filesystem/vocab checks below operate on the validated object.
     # try/except is required here: pydantic raises a single ValidationError for all
     # structural problems, which we translate into the broker's flat-list format.
     try:
-        DatasetConfig.model_validate(cfg)
+        config = DatasetConfig.model_validate(cfg)
     except PydanticValidationError as e:
-        errors.extend(_format_model_errors(e))
+        raise ValidationError(_format_model_errors(e))
 
-    # --- Filesystem + advisory checks (kept out of the pure model) ---
-    data = cfg.get("data")
-    directory = data.get("directory") if isinstance(data, dict) else None
-    if isinstance(directory, str) and directory and not os.path.isdir(directory):
-        errors.append(f"'data.directory' does not exist: {directory}")
-    if isinstance(data, dict) and not data.get("file_pattern"):
+    # Filesystem check (kept out of the pure model so a config can be validated
+    # without its data present — but enforced here when the directory is given).
+    if not os.path.isdir(config.data.directory):
+        raise ValidationError(
+            [f"'data.directory' does not exist: {config.data.directory}"]
+        )
+    if not config.data.file_pattern:
         warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
 
-    # --- Provenance (optional, no special validation) ---
-
-    # --- Dataset container metadata: validate against semantic model ---
-    metadata = cfg.get("metadata")
-    if not isinstance(metadata, dict):
-        metadata = {}
+    # Dataset metadata: soft controlled-vocabulary checks (warnings only, ADR-0003).
+    metadata = config.metadata
     if model:
         _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
         _validate_vocab(metadata, "data_type", "data_types", model, warnings)
@@ -211,27 +206,22 @@ def validate(cfg, model_path=None):
         _validate_vocab(metadata, "facility", "facilities", model, warnings)
         _validate_vocab(metadata, "project", "projects", model, warnings)
 
-    # --- Cross-field validation ---
-    dt = metadata.get("data_type")
-    if dt == "experimental" and not metadata.get("facility"):
+    # Cross-field advisory checks (producer↔simulation, facility↔experimental).
+    dt = metadata.data_type
+    if dt == "experimental" and not metadata.facility:
         warnings.append("data_type is 'experimental' but no 'facility' specified")
-    if dt == "simulation" and not metadata.get("producer"):
+    if dt == "simulation" and not metadata.producer:
         warnings.append("data_type is 'simulation' but no 'producer' specified")
-    if dt == "experimental" and metadata.get("producer"):
+    if dt == "experimental" and metadata.producer:
         warnings.append(
             "data_type is 'experimental' but 'producer' is set"
             " — producer is typically for simulations"
         )
-    if dt == "simulation" and metadata.get("facility"):
+    if dt == "simulation" and metadata.facility:
         warnings.append(
             "data_type is 'simulation' but 'facility' is set"
             " — facility is typically for experiments"
         )
-    if not metadata.get("material"):
-        warnings.append("'material' not specified — recommended for discoverability")
-
-    if errors:
-        raise ValidationError(errors)
 
     return warnings
 
@@ -239,9 +229,10 @@ def validate(cfg, model_path=None):
 def _validate_vocab(metadata, field, model_key, model, warnings, is_list=False):
     """Check a metadata field against the catalog model vocabulary.
 
-    Accepts both canonical IDs and known aliases.
+    `metadata` is a validated DatasetMetadata model. Accepts both canonical IDs
+    and known aliases.
     """
-    value = metadata.get(field)
+    value = getattr(metadata, field, None)
     if value is None:
         return
     allowed = get_allowed_values(model, model_key)

--- a/src/tiled_catalog_broker/tools/schema.py
+++ b/src/tiled_catalog_broker/tools/schema.py
@@ -7,10 +7,10 @@ and the semantic model (schema/catalog_model.yml).
 import os
 from pathlib import Path
 
+from pydantic import ValidationError as PydanticValidationError
 from ruamel.yaml import YAML
 
-VALID_LAYOUTS = {"per_entity", "batched", "grouped"}
-VALID_PARAM_LOCATIONS = {"root_scalars", "root_attributes", "group", "group_scalars", "manifest"}
+from ._models import DatasetConfig
 
 
 class ValidationError(Exception):
@@ -145,6 +145,20 @@ def resolve_aliases(cfg, model):
     return messages
 
 
+def _format_model_errors(exc):
+    """Translate a pydantic ValidationError into the broker's flat error strings.
+
+    Each pydantic error becomes a "<dotted.location>: <message>" line so the existing
+    ``ValidationError(errors)`` message format (and substring-based tests) keep working.
+    """
+    messages = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err["loc"])
+        msg = err["msg"].removeprefix("Value error, ")
+        messages.append(f"{loc}: {msg}" if loc else msg)
+    return messages
+
+
 def validate(cfg, model_path=None):
     """Validate a parsed dataset YAML config.
 
@@ -167,73 +181,28 @@ def validate(cfg, model_path=None):
     for msg in alias_messages:
         warnings.append(msg)
 
-    # --- Required identity fields ---
-    if not cfg.get("label"):
-        errors.append("'label' is required (e.g., edrixs_sbi)")
-    if not cfg.get("key"):
-        if not cfg.get("key_prefix"):
-            errors.append("'key' is required (dataset container key in Tiled)")
+    # --- Structural validation via the pydantic contract model ---
+    # try/except is required here: pydantic raises a single ValidationError for all
+    # structural problems, which we translate into the broker's flat-list format.
+    try:
+        DatasetConfig.model_validate(cfg)
+    except PydanticValidationError as e:
+        errors.extend(_format_model_errors(e))
 
-    # --- Data section ---
+    # --- Filesystem + advisory checks (kept out of the pure model) ---
     data = cfg.get("data")
-    if not data:
-        errors.append("'data' section is required")
-    else:
-        if not data.get("directory"):
-            errors.append("'data.directory' is required")
-        elif not os.path.isdir(data["directory"]):
-            errors.append(f"'data.directory' does not exist: {data['directory']}")
-
-        layout = data.get("layout")
-        if not layout:
-            errors.append("'data.layout' is required (per_entity | batched | grouped)")
-        elif layout not in VALID_LAYOUTS:
-            errors.append(f"'data.layout' must be one of {VALID_LAYOUTS}, got '{layout}'")
-
-        if not data.get("file_pattern"):
-            warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
-
-        sbd = data.get("server_base_dir")
-        if sbd is not None and sbd != "" and not isinstance(sbd, str):
-            errors.append(
-                f"'data.server_base_dir' must be a string if set, got {type(sbd).__name__}"
-            )
-
-    # --- Artifacts ---
-    artifacts = cfg.get("artifacts", [])
-    if not artifacts:
-        errors.append("'artifacts' list is required (at least one artifact)")
-    else:
-        for i, art in enumerate(artifacts):
-            if not art.get("type"):
-                errors.append(f"artifacts[{i}].type is required")
-            if not art.get("dataset"):
-                errors.append(f"artifacts[{i}].dataset is required")
-
-    # --- Parameters (optional but validated if present) ---
-    params = cfg.get("parameters")
-    if params:
-        loc = params.get("location")
-        if loc and loc not in VALID_PARAM_LOCATIONS:
-            errors.append(
-                f"'parameters.location' must be one of {VALID_PARAM_LOCATIONS}, got '{loc}'"
-            )
-        if loc == "group" and not params.get("group"):
-            errors.append("'parameters.group' is required when location is 'group'")
-        if loc == "manifest" and not params.get("manifest"):
-            errors.append("'parameters.manifest' is required when location is 'manifest'")
-
-    # --- Shared axes (optional, validated if present) ---
-    for i, ax in enumerate(cfg.get("shared", [])):
-        if not ax.get("type"):
-            errors.append(f"shared[{i}].type is required")
-        if not ax.get("dataset"):
-            errors.append(f"shared[{i}].dataset is required")
+    directory = data.get("directory") if isinstance(data, dict) else None
+    if isinstance(directory, str) and directory and not os.path.isdir(directory):
+        errors.append(f"'data.directory' does not exist: {directory}")
+    if isinstance(data, dict) and not data.get("file_pattern"):
+        warnings.append("'data.file_pattern' not set — will default to '**/*.h5'")
 
     # --- Provenance (optional, no special validation) ---
 
     # --- Dataset container metadata: validate against semantic model ---
-    metadata = cfg.get("metadata", {})
+    metadata = cfg.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
     if model:
         _validate_vocab(metadata, "method", "methods", model, warnings, is_list=True)
         _validate_vocab(metadata, "data_type", "data_types", model, warnings)

--- a/src/tiled_catalog_broker/tools/schema/catalog_model.yml
+++ b/src/tiled_catalog_broker/tools/schema/catalog_model.yml
@@ -105,7 +105,10 @@ producers:
     description: Exact-diagonalization RIXS simulation library (Python)
 
 # --- Dataset metadata fields ---
-# Defines which fields are required/optional on dataset container metadata.
+# Advisory reference: which metadata fields exist and which vocabulary each draws from.
+# NOTE: the validator does NOT hard-require these — unknown/missing values produce
+# warnings, not errors (see docs/adr/0003). The required/optional split here drives draft
+# hints and documentation, not enforcement.
 dataset_fields:
   required:
     - name: data_type

--- a/src/tiled_catalog_broker/tools/schema/catalog_model.yml
+++ b/src/tiled_catalog_broker/tools/schema/catalog_model.yml
@@ -119,15 +119,15 @@ dataset_fields:
       type: list
       enum_ref: methods
       description: Scientific methods/observables (list)
+    - name: material
+      type: string
+      enum_ref: materials
+      description: Target material or system
   optional:
     - name: project
       type: string
       enum_ref: projects
       description: Scientific project or collaboration
-    - name: material
-      type: string
-      enum_ref: materials
-      description: Target material or system
     - name: producer
       type: string
       enum_ref: producers

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -151,14 +151,6 @@ class TestValidate:
         warnings = validate(minimal_valid_config)
         assert isinstance(warnings, list)
 
-    def test_validate_missing_key(self, minimal_valid_config):
-        """Raises ValidationError when 'key' is missing."""
-        del minimal_valid_config["key"]
-        del minimal_valid_config["label"]
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("label" in e.lower() or "key" in e.lower() for e in exc_info.value.errors)
-
     def test_validate_missing_artifacts(self, minimal_valid_config):
         """Raises ValidationError when artifacts list is empty."""
         minimal_valid_config["artifacts"] = []
@@ -166,12 +158,20 @@ class TestValidate:
             validate(minimal_valid_config)
         assert any("artifact" in e.lower() for e in exc_info.value.errors)
 
-    def test_validate_bad_layout(self, minimal_valid_config):
-        """Raises ValidationError for an invalid layout value."""
-        minimal_valid_config["data"]["layout"] = "invalid_layout"
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("layout" in e.lower() for e in exc_info.value.errors)
+    def test_validate_missing_metadata_field(self, minimal_valid_config):
+        """data_type, method, material are required (presence) — missing → error."""
+        for field in ("data_type", "method", "material"):
+            cfg = {**minimal_valid_config, "metadata": dict(minimal_valid_config["metadata"])}
+            del cfg["metadata"][field]
+            with pytest.raises(ValidationError) as exc_info:
+                validate(cfg)
+            assert any(field in e.lower() for e in exc_info.value.errors)
+
+    def test_validate_unknown_metadata_value_warns_not_errors(self, minimal_valid_config):
+        """A required field with an out-of-vocab *value* still validates (warns only)."""
+        minimal_valid_config["metadata"]["material"] = "SomeNovelMaterial"
+        warnings = validate(minimal_valid_config)  # must not raise
+        assert isinstance(warnings, list)
 
     def test_validate_alias_accepted(self, minimal_valid_config):
         """EDRIXS in method doesn't produce a vocab warning."""
@@ -191,33 +191,12 @@ class TestValidate:
 class TestModelContract:
     """Tests for the pydantic-backed structural contract (tools/_models.py)."""
 
-    def test_key_prefix_satisfies_identity(self, minimal_valid_config):
-        """key_prefix is an accepted alternative to key."""
+    def test_key_required(self, minimal_valid_config):
+        """`key` is the sole identity field — absent (even with a label) → error."""
         del minimal_valid_config["key"]
-        minimal_valid_config["key_prefix"] = "TEST_"
-        warnings = validate(minimal_valid_config)
-        assert isinstance(warnings, list)
-
-    def test_empty_label_rejected(self, minimal_valid_config):
-        """An empty-string label is treated as missing (min_length=1)."""
-        minimal_valid_config["label"] = ""
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
-        assert any("label" in e.lower() for e in exc_info.value.errors)
-
-    def test_empty_artifact_field_rejected(self, minimal_valid_config):
-        """An empty artifact type/dataset is treated as missing."""
-        minimal_valid_config["artifacts"] = [{"type": "", "dataset": "/x"}]
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("type" in e.lower() for e in exc_info.value.errors)
-
-    def test_unknown_key_in_data_rejected(self, minimal_valid_config):
-        """forbid: a typo'd key in the data section is rejected, not silently dropped."""
-        minimal_valid_config["data"]["file_patern"] = "*.h5"  # typo
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("file_patern" in e for e in exc_info.value.errors)
+        assert any("key" in e.lower() for e in exc_info.value.errors)
 
     def test_params_group_requires_group(self, minimal_valid_config):
         """location=group without a group field is rejected."""
@@ -237,13 +216,6 @@ class TestModelContract:
             "location": "group_scalars", "entity_group": "samples"
         }
         assert isinstance(validate(minimal_valid_config), list)
-
-    def test_bad_param_location_rejected(self, minimal_valid_config):
-        """An unknown parameters.location value is rejected."""
-        minimal_valid_config["parameters"] = {"location": "not_a_location"}
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("location" in e.lower() for e in exc_info.value.errors)
 
     def test_shared_axis_requires_dataset(self, minimal_valid_config):
         """A shared axis missing its dataset is rejected."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "pytest",
 #     "ruamel.yaml",
+#     "pydantic>=2",
 # ]
 # ///
 """
@@ -185,3 +186,74 @@ class TestValidate:
         del minimal_valid_config["metadata"]["producer"]
         warnings = validate(minimal_valid_config)
         assert any("simulation" in w and "producer" in w for w in warnings)
+
+
+class TestModelContract:
+    """Tests for the pydantic-backed structural contract (tools/_models.py)."""
+
+    def test_key_prefix_satisfies_identity(self, minimal_valid_config):
+        """key_prefix is an accepted alternative to key."""
+        del minimal_valid_config["key"]
+        minimal_valid_config["key_prefix"] = "TEST_"
+        warnings = validate(minimal_valid_config)
+        assert isinstance(warnings, list)
+
+    def test_empty_label_rejected(self, minimal_valid_config):
+        """An empty-string label is treated as missing (min_length=1)."""
+        minimal_valid_config["label"] = ""
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("label" in e.lower() for e in exc_info.value.errors)
+
+    def test_empty_artifact_field_rejected(self, minimal_valid_config):
+        """An empty artifact type/dataset is treated as missing."""
+        minimal_valid_config["artifacts"] = [{"type": "", "dataset": "/x"}]
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("type" in e.lower() for e in exc_info.value.errors)
+
+    def test_unknown_key_in_data_rejected(self, minimal_valid_config):
+        """forbid: a typo'd key in the data section is rejected, not silently dropped."""
+        minimal_valid_config["data"]["file_patern"] = "*.h5"  # typo
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("file_patern" in e for e in exc_info.value.errors)
+
+    def test_params_group_requires_group(self, minimal_valid_config):
+        """location=group without a group field is rejected."""
+        minimal_valid_config["parameters"] = {"location": "group"}
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("group" in e.lower() for e in exc_info.value.errors)
+
+    def test_params_manifest_requires_manifest(self, minimal_valid_config):
+        """location=manifest without a manifest field is rejected."""
+        minimal_valid_config["parameters"] = {"location": "manifest"}
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("manifest" in e.lower() for e in exc_info.value.errors)
+
+    def test_params_group_valid(self, minimal_valid_config):
+        """location=group with a group field passes."""
+        minimal_valid_config["parameters"] = {"location": "group", "group": "/params"}
+        assert isinstance(validate(minimal_valid_config), list)
+
+    def test_bad_param_location_rejected(self, minimal_valid_config):
+        """An unknown parameters.location value is rejected."""
+        minimal_valid_config["parameters"] = {"location": "not_a_location"}
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("location" in e.lower() for e in exc_info.value.errors)
+
+    def test_shared_axis_requires_dataset(self, minimal_valid_config):
+        """A shared axis missing its dataset is rejected."""
+        minimal_valid_config["shared"] = [{"type": "E_axis"}]
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert any("dataset" in e.lower() for e in exc_info.value.errors)
+
+    def test_extra_metadata_keys_allowed(self, minimal_valid_config):
+        """metadata is extensible — unknown metadata keys do not error."""
+        minimal_valid_config["metadata"]["prior_distribution"] = "uniform"
+        minimal_valid_config["metadata"]["round"] = 0
+        assert isinstance(validate(minimal_valid_config), list)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -24,8 +24,9 @@ import pytest
 # Add project root to path for package imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from pydantic import ValidationError
+
 from tiled_catalog_broker.tools.schema import (
-    ValidationError,
     get_alias_map,
     get_allowed_values,
     load_catalog_model,
@@ -69,11 +70,6 @@ class TestLoadCatalogModel:
         assert isinstance(model, dict)
         assert "methods" in model
 
-    def test_load_catalog_model_missing(self):
-        """Returns None for a nonexistent path."""
-        result = load_catalog_model("/nonexistent/path/catalog_model.yml")
-        assert result is None
-
 
 class TestGetAllowedValues:
     """Tests for get_allowed_values()."""
@@ -93,10 +89,6 @@ class TestGetAllowedValues:
         """Returns empty list for a field not in the model."""
         model = {"methods": [{"id": "RIXS"}]}
         assert get_allowed_values(model, "materials") == []
-
-    def test_get_allowed_values_none_model(self):
-        """Returns empty list when model is None."""
-        assert get_allowed_values(None, "methods") == []
 
 
 class TestGetAliasMap:
@@ -156,7 +148,7 @@ class TestValidate:
         minimal_valid_config["artifacts"] = []
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
-        assert any("artifact" in e.lower() for e in exc_info.value.errors)
+        assert "artifact" in str(exc_info.value).lower()
 
     def test_validate_missing_metadata_field(self, minimal_valid_config):
         """data_type, method, material are required (presence) — missing → error."""
@@ -165,7 +157,7 @@ class TestValidate:
             del cfg["metadata"][field]
             with pytest.raises(ValidationError) as exc_info:
                 validate(cfg)
-            assert any(field in e.lower() for e in exc_info.value.errors)
+            assert field in str(exc_info.value).lower()
 
     def test_validate_unknown_metadata_value_warns_not_errors(self, minimal_valid_config):
         """A required field with an out-of-vocab *value* still validates (warns only)."""
@@ -196,14 +188,14 @@ class TestModelContract:
         del minimal_valid_config["key"]
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
-        assert any("key" in e.lower() for e in exc_info.value.errors)
+        assert "key" in str(exc_info.value).lower()
 
     def test_params_group_requires_group(self, minimal_valid_config):
         """location=group without a group field is rejected."""
         minimal_valid_config["parameters"] = {"location": "group"}
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
-        assert any("group" in e.lower() for e in exc_info.value.errors)
+        assert "group" in str(exc_info.value).lower()
 
     def test_params_group_valid(self, minimal_valid_config):
         """location=group with a group field passes."""
@@ -222,7 +214,7 @@ class TestModelContract:
         minimal_valid_config["shared"] = [{"type": "E_axis"}]
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
-        assert any("dataset" in e.lower() for e in exc_info.value.errors)
+        assert "dataset" in str(exc_info.value).lower()
 
     def test_extra_metadata_keys_allowed(self, minimal_valid_config):
         """metadata is extensible — unknown metadata keys do not error."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -226,13 +226,6 @@ class TestModelContract:
             validate(minimal_valid_config)
         assert any("group" in e.lower() for e in exc_info.value.errors)
 
-    def test_params_manifest_requires_manifest(self, minimal_valid_config):
-        """location=manifest without a manifest field is rejected."""
-        minimal_valid_config["parameters"] = {"location": "manifest"}
-        with pytest.raises(ValidationError) as exc_info:
-            validate(minimal_valid_config)
-        assert any("manifest" in e.lower() for e in exc_info.value.errors)
-
     def test_params_group_valid(self, minimal_valid_config):
         """location=group with a group field passes."""
         minimal_valid_config["parameters"] = {"location": "group", "group": "/params"}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -51,6 +51,7 @@ def minimal_valid_config(tmp_path):
         "artifacts": [
             {"type": "spectrum", "dataset": "/spectrum"},
         ],
+        "parameters": {"location": "root_scalars"},
         "metadata": {
             "method": ["RIXS"],
             "data_type": "simulation",
@@ -189,6 +190,20 @@ class TestModelContract:
         with pytest.raises(ValidationError) as exc_info:
             validate(minimal_valid_config)
         assert "key" in str(exc_info.value).lower()
+
+    def test_parameters_required(self, minimal_valid_config):
+        """The parameters section (and its location) is required."""
+        del minimal_valid_config["parameters"]
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert "parameters" in str(exc_info.value).lower()
+
+    def test_params_location_required(self, minimal_valid_config):
+        """parameters.location must be present."""
+        minimal_valid_config["parameters"] = {}
+        with pytest.raises(ValidationError) as exc_info:
+            validate(minimal_valid_config)
+        assert "location" in str(exc_info.value).lower()
 
     def test_params_group_requires_group(self, minimal_valid_config):
         """location=group without a group field is rejected."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -238,6 +238,13 @@ class TestModelContract:
         minimal_valid_config["parameters"] = {"location": "group", "group": "/params"}
         assert isinstance(validate(minimal_valid_config), list)
 
+    def test_params_entity_group_allowed(self, minimal_valid_config):
+        """grouped layout declares parameters.entity_group — it must be accepted."""
+        minimal_valid_config["parameters"] = {
+            "location": "group_scalars", "entity_group": "samples"
+        }
+        assert isinstance(validate(minimal_valid_config), list)
+
     def test_bad_param_location_rejected(self, minimal_valid_config):
         """An unknown parameters.location value is rejected."""
         minimal_valid_config["parameters"] = {"location": "not_a_location"}


### PR DESCRIPTION
Replaces the dataset-YAML validator's hand-written `.get()` checks with declarative pydantic v2 models, so the structural contract is now a single readable artifact (`tools/_models.py`) instead of imperative logic buried in `schema.py`. Behavior is preserved — same error format, alias resolution, and soft vocabulary warnings — and the full suite stays green (25 schema tests, 130 overall). This is the first slice of the onboarding-simplification effort.

First slice of #71. Description format per @swelborn's note on #32.

<details>
<summary>Details</summary>

**New: `tools/_models.py`** — `DatasetConfig` + `DataSection` / `ArtifactSpec` / `SharedAxisSpec` / `ParametersSection` / `DatasetMetadata`, with `Layout` / `ParamLocation` enums.
- `forbid` extras on the closed sub-sections (catches typos like `file_patern:` that the old validator silently dropped); `metadata` stays `extra="allow"`.
- `min_length=1` on required strings so `""` is treated as missing, matching the old `if not x` checks.
- `@model_validator` for the `key`/`key_prefix` one-of and the `parameters.location` → `group`/`manifest` conditionals.

**`schema.py`** — `validate()` now parses via `DatasetConfig.model_validate` and translates pydantic errors into the existing flat `ValidationError(errors)` format (`_format_model_errors`). Alias resolution, `_validate_vocab` warnings, cross-field advisories, and the `isdir` filesystem check are unchanged. Removed the now-dead `VALID_LAYOUTS` / `VALID_PARAM_LOCATIONS` constants (the enums own them).

**`catalog_model.yml`** — comment-only fix: `dataset_fields` now states it's advisory (warnings, not enforcement), per ADR-0003.

**`pyproject.toml`** — `pydantic>=2` made explicit (already transitive via `tiled[server]`).

**Direction docs (ride with this PR):** `CONTEXT.md` (glossary + implementation-vs-contract principle) and `docs/adr/0001-0003` (freeze 3 layouts; single registration route; vocab is soft normalization).

**Tests:** 15 original `test_schema.py` tests pass unchanged + 10 new `TestModelContract` tests (forbid, min_length, one-of key, params conditionals, extensible metadata).

Follow-ups (separate PRs): generate dedupe (`refactor/generate-dedup`), inspect deletion + onboarding docs (`refactor/onboarding-docs`), single registration route (`refactor/single-register`).
</details>